### PR TITLE
Added support for idempotencyKey for POST methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,16 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased][unreleased]
+
+### Added
+
+- Support for `idempotencyKey` for `POST` methods by @aydrian & @rileylnapier
+
 ## [v1.5.0] - 2020-07-08
 
 ### Added
+
 - Support for [Brands API](https://docs.trycourier.com/reference/brands-api) by @aydrian
   - `GET /brands` via `client.getBrands(params)`
   - `GET /brands/:brand_id` via `client.getBrand(brandId)`
@@ -67,6 +74,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.0.1 - 2019-07-12
 
+[unreleased]: https://github.com/trycourier/courier-python/compare/v1.5.0...HEAD
 [v1.5.0]: https://github.com/trycourier/courier-python/compare/v1.4.0...v1.5.0
 [v1.4.0]: https://github.com/trycourier/courier-python/compare/v1.3.0...v1.4.0
 [v1.3.0]: https://github.com/trycourier/courier-python/compare/v1.2.1...v1.3.0

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ const { messageId } = await courier.send({
   recipientId: "<RECIPIENT_ID>", // usually your system's User ID
   profile: {
     email: "example@example.com",
-    phone_number: "555-228-3890"
+    phone_number: "555-228-3890",
   },
-  data: {} // optional variables for merging into templates
+  data: {}, // optional variables for merging into templates
 });
 ```
 
@@ -52,7 +52,7 @@ async function run() {
     data: {}, // optional
     brand: "<BRAND_ID>", //optional
     preferences: {}, // optional
-    override: {} // optional
+    override: {}, // optional
   });
   console.log(messageId);
 
@@ -64,8 +64,8 @@ async function run() {
   const { status: replaceStatus } = await courier.replaceProfile({
     recipientId: "<RECIPIENT_ID>",
     profile: {
-      email: "example@example.com"
-    }
+      email: "example@example.com",
+    },
   });
   console.log(replaceStatus);
 
@@ -73,20 +73,20 @@ async function run() {
   const { status: mergeStatus } = await courier.mergeProfile({
     recipientId: "<RECIPIENT_ID>",
     profile: {
-      sms: "555-555-5555"
-    }
+      sms: "555-555-5555",
+    },
   });
   console.log(mergeStatus);
 
   // Example: get a recipient's profile
   const { profile } = await courier.getProfile({
-    recipientId: "<RECIPIENT_ID>"
+    recipientId: "<RECIPIENT_ID>",
   });
   console.log(profile);
 
   // Example: get all brands
-  const {paging, results} = await courier.getBrands({
-    cursor: "<CURSOR>" // optional
+  const { paging, results } = await courier.getBrands({
+    cursor: "<CURSOR>", // optional
   });
   console.log(results);
 
@@ -101,9 +101,9 @@ async function run() {
       color: {
         primary: "#0000FF",
         secondary: "#FF0000",
-        tertiary: "#00FF00"
-      }
-    }
+        tertiary: "#00FF00",
+      },
+    },
   });
   console.log(newBrand);
 
@@ -115,14 +115,48 @@ async function run() {
       color: {
         primary: "#FF0000",
         secondary: "#00FF00",
-        tertiary: "#0000FF"
-      }
-    }
+        tertiary: "#0000FF",
+      },
+    },
   });
   console.log(replacedBrand);
 
   // Example: delete a brand
   await courier.deleteBrand("<BRAND_ID>");
+}
+
+run();
+```
+
+### Idempotency
+
+For `POST` methods, you can supply an `idempotencyKey` in the config parameter to ensure the idempotency of the API Call. We recommend that you use a `V4 UUID` for the key. Keys are eligible to be removed from the system after they're at least 24 hours old, and a new request is generated if a key is reused after the original has been removed. For more info, see [Idempotent Requests](https://docs.trycourier.com/reference/idempotent-requests) in the Courier Documentation.
+
+```javascript
+import { CourierClient } from "@trycourier/courier";
+import uuid4 from "uuid4";
+
+const courier = CourierClient();
+const idempotencyKey = uuid4();
+
+async function run() {
+  const { messageId } = await courier.send(
+    {
+      eventId: "<EVENT_ID>",
+      recipientId: "<RECIPIENT_ID>",
+      profile: {
+        email: "example@example.com",
+        phone_number: "555-867-5309",
+      },
+      data: {
+        world: "JavaScript!",
+      },
+    },
+    {
+      idempotencyKey,
+    }
+  );
+  console.log(messageId);
 }
 
 run();

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ const { messageId } = await courier.send({
   recipientId: "<RECIPIENT_ID>", // usually your system's User ID
   profile: {
     email: "example@example.com",
-    phone_number: "555-228-3890",
+    phone_number: "555-228-3890"
   },
-  data: {}, // optional variables for merging into templates
+  data: {} // optional variables for merging into templates
 });
 ```
 
@@ -52,7 +52,7 @@ async function run() {
     data: {}, // optional
     brand: "<BRAND_ID>", //optional
     preferences: {}, // optional
-    override: {}, // optional
+    override: {} // optional
   });
   console.log(messageId);
 
@@ -64,8 +64,8 @@ async function run() {
   const { status: replaceStatus } = await courier.replaceProfile({
     recipientId: "<RECIPIENT_ID>",
     profile: {
-      email: "example@example.com",
-    },
+      email: "example@example.com"
+    }
   });
   console.log(replaceStatus);
 
@@ -73,20 +73,20 @@ async function run() {
   const { status: mergeStatus } = await courier.mergeProfile({
     recipientId: "<RECIPIENT_ID>",
     profile: {
-      sms: "555-555-5555",
-    },
+      sms: "555-555-5555"
+    }
   });
   console.log(mergeStatus);
 
   // Example: get a recipient's profile
   const { profile } = await courier.getProfile({
-    recipientId: "<RECIPIENT_ID>",
+    recipientId: "<RECIPIENT_ID>"
   });
   console.log(profile);
 
   // Example: get all brands
   const { paging, results } = await courier.getBrands({
-    cursor: "<CURSOR>", // optional
+    cursor: "<CURSOR>" // optional
   });
   console.log(results);
 
@@ -101,9 +101,9 @@ async function run() {
       color: {
         primary: "#0000FF",
         secondary: "#FF0000",
-        tertiary: "#00FF00",
-      },
-    },
+        tertiary: "#00FF00"
+      }
+    }
   });
   console.log(newBrand);
 
@@ -115,9 +115,9 @@ async function run() {
       color: {
         primary: "#FF0000",
         secondary: "#00FF00",
-        tertiary: "#0000FF",
-      },
-    },
+        tertiary: "#0000FF"
+      }
+    }
   });
   console.log(replacedBrand);
 
@@ -146,14 +146,14 @@ async function run() {
       recipientId: "<RECIPIENT_ID>",
       profile: {
         email: "example@example.com",
-        phone_number: "555-867-5309",
+        phone_number: "555-867-5309"
       },
       data: {
-        world: "JavaScript!",
-      },
+        world: "JavaScript!"
+      }
     },
     {
-      idempotencyKey,
+      idempotencyKey
     }
   );
   console.log(messageId);

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -8,31 +8,31 @@ import {
   ICourierProfileGetResponse,
   ICourierProfilePostResponse,
   ICourierProfilePutResponse,
-  ICourierSendResponse,
+  ICourierSendResponse
 } from "../types";
 
 const mockSendResponse: ICourierSendResponse = {
-  messageId: "1234",
+  messageId: "1234"
 };
 
 const mockReplaceProfileResponse: ICourierProfilePutResponse = {
-  status: "SUCCESS",
+  status: "SUCCESS"
 };
 
 const mockMergeProfileResponse: ICourierProfilePostResponse = {
-  status: "SUCCESS",
+  status: "SUCCESS"
 };
 
 const mockGetProfileResponse: ICourierProfileGetResponse = {
   profile: {
-    name: "Troy",
-  },
+    name: "Troy"
+  }
 };
 
 const mockGetMessageResponse: ICourierMessageGetResponse = {
   id: "mockMessageId",
   recipient: "mockRecipient",
-  status: "mockStatus",
+  status: "mockStatus"
 };
 
 const mockBrandResponse: ICourierBrand = {
@@ -44,19 +44,19 @@ const mockBrandResponse: ICourierBrand = {
     email: {
       footer: {},
       header: {
-        barColor: "#9D3789",
-      },
-    },
+        barColor: "#9D3789"
+      }
+    }
   },
   updated: 1591814489143,
-  version: "2020-06-10T18:41:29.093Z",
+  version: "2020-06-10T18:41:29.093Z"
 };
 
 const mockGetBrandsResponse: ICourierBrandGetAllResponse = {
   paging: {
-    more: false,
+    more: false
   },
-  results: [mockBrandResponse],
+  results: [mockBrandResponse]
 };
 
 describe("CourierClient", () => {
@@ -77,26 +77,26 @@ describe("CourierClient", () => {
 
   test(".send", async () => {
     const { send } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
       send({
         data: {
-          example: "EXAMPLE_DATA",
+          example: "EXAMPLE_DATA"
         },
         eventId: "EVENT_ID",
         profile: {
-          sms: "PHONE_NUMBER",
+          sms: "PHONE_NUMBER"
         },
-        recipientId: "RECIPIENT_ID",
+        recipientId: "RECIPIENT_ID"
       })
     ).resolves.toMatchObject(mockSendResponse);
   });
 
   test(".send with Idempotency Key", async () => {
     const { send } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     mock.onPost("/send").reply(async (config) => {
@@ -107,23 +107,23 @@ describe("CourierClient", () => {
     await send(
       {
         data: {
-          example: "EXAMPLE_DATA",
+          example: "EXAMPLE_DATA"
         },
         eventId: "EVENT_ID",
         profile: {
-          sms: "PHONE_NUMBER",
+          sms: "PHONE_NUMBER"
         },
-        recipientId: "RECIPIENT_ID",
+        recipientId: "RECIPIENT_ID"
       },
       {
-        idempotencyKey: "IDEMPOTENCY_KEY_UUID",
+        idempotencyKey: "IDEMPOTENCY_KEY_UUID"
       }
     );
   });
 
   test(".getMessage", async () => {
     const { getMessage } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(getMessage(mockGetMessageResponse.id)).resolves.toMatchObject(
@@ -133,37 +133,37 @@ describe("CourierClient", () => {
 
   test(".replaceProfile", async () => {
     const { replaceProfile } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
       replaceProfile({
         profile: {
-          foo: "bar",
+          foo: "bar"
         },
-        recipientId: "RECIPIENT_ID",
+        recipientId: "RECIPIENT_ID"
       })
     ).resolves.toMatchObject(mockReplaceProfileResponse);
   });
 
   test(".mergeProfile", async () => {
     const { mergeProfile } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
       mergeProfile({
         profile: {
-          foo: "bar",
+          foo: "bar"
         },
-        recipientId: "RECIPIENT_ID",
+        recipientId: "RECIPIENT_ID"
       })
     ).resolves.toMatchObject(mockMergeProfileResponse);
   });
 
   test(".mergeProfile with Idempotency Key", async () => {
     const { mergeProfile } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     mock.onPost(/\/profiles\/.*/).reply(async (config) => {
@@ -174,31 +174,31 @@ describe("CourierClient", () => {
     await mergeProfile(
       {
         profile: {
-          foo: "bar",
+          foo: "bar"
         },
-        recipientId: "RECIPIENT_ID",
+        recipientId: "RECIPIENT_ID"
       },
       {
-        idempotencyKey: "IDEMPOTENCY_KEY_UUID",
+        idempotencyKey: "IDEMPOTENCY_KEY_UUID"
       }
     );
   });
 
   test(".getProfile", async () => {
     const { getProfile } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
       getProfile({
-        recipientId: "RECIPIENT_ID",
+        recipientId: "RECIPIENT_ID"
       })
     ).resolves.toMatchObject(mockGetProfileResponse);
   });
 
   test(".getBrands", async () => {
     const { getBrands } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(getBrands()).resolves.toMatchObject(mockGetBrandsResponse);
@@ -206,7 +206,7 @@ describe("CourierClient", () => {
 
   test(".getBrand", async () => {
     const { getBrand } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
@@ -216,7 +216,7 @@ describe("CourierClient", () => {
 
   test(".createBrand", async () => {
     const { createBrand } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
@@ -227,17 +227,17 @@ describe("CourierClient", () => {
           email: {
             footer: {},
             header: {
-              barColor: "#9D3789",
-            },
-          },
-        },
+              barColor: "#9D3789"
+            }
+          }
+        }
       })
     ).resolves.toMatchObject(mockBrandResponse);
   });
 
   test(".createBrand with Idempotency Key", async () => {
     const { createBrand } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     mock.onPost("/brands").reply(async (config) => {
@@ -253,20 +253,20 @@ describe("CourierClient", () => {
           email: {
             footer: {},
             header: {
-              barColor: "#9D3789",
-            },
-          },
-        },
+              barColor: "#9D3789"
+            }
+          }
+        }
       },
       {
-        idempotencyKey: "IDEMPOTENCY_KEY_UUID",
+        idempotencyKey: "IDEMPOTENCY_KEY_UUID"
       }
     );
   });
 
   test(".replaceBrand", async () => {
     const { replaceBrand } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
@@ -277,17 +277,17 @@ describe("CourierClient", () => {
           email: {
             footer: {},
             header: {
-              barColor: "#9D3789",
-            },
-          },
-        },
+              barColor: "#9D3789"
+            }
+          }
+        }
       })
     ).resolves.toMatchObject(mockBrandResponse);
   });
 
   test(".deleteBrand", async () => {
     const { deleteBrand } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(

--- a/src/brands.ts
+++ b/src/brands.ts
@@ -5,7 +5,7 @@ import {
   ICourierBrandParameters,
   ICourierBrandPostConfig,
   ICourierBrandPutParameters,
-  ICourierClientConfiguration,
+  ICourierClientConfiguration
 } from "./types";
 
 export const getBrands = (options: ICourierClientConfiguration) => {
@@ -35,7 +35,7 @@ export const createBrand = (options: ICourierClientConfiguration) => {
     config?: ICourierBrandPostConfig
   ): Promise<ICourierBrand> => {
     const axiosConfig: AxiosRequestConfig = {
-      headers: {},
+      headers: {}
     };
 
     if (config && config.idempotencyKey) {

--- a/src/brands.ts
+++ b/src/brands.ts
@@ -1,28 +1,27 @@
-import { 
-  ICourierBrand, 
+import { AxiosRequestConfig } from "axios";
+import {
+  ICourierBrand,
   ICourierBrandGetAllResponse,
   ICourierBrandParameters,
+  ICourierBrandPostConfig,
   ICourierBrandPutParameters,
-  ICourierClientConfiguration
+  ICourierClientConfiguration,
 } from "./types";
 
 export const getBrands = (options: ICourierClientConfiguration) => {
-  return async (
-    params?: {
-      cursor: string;
-    }
-  ): Promise<ICourierBrandGetAllResponse> => {
+  return async (params?: {
+    cursor: string;
+  }): Promise<ICourierBrandGetAllResponse> => {
     const res = await options.httpClient.get<ICourierBrandGetAllResponse>(
-      `/brands`, params
+      `/brands`,
+      params
     );
     return res.data;
   };
 };
 
 export const getBrand = (options: ICourierClientConfiguration) => {
-  return async (
-    brandId: string
-  ): Promise<ICourierBrand> => {
+  return async (brandId: string): Promise<ICourierBrand> => {
     const res = await options.httpClient.get<ICourierBrand>(
       `/brands/${brandId}`
     );
@@ -32,21 +31,28 @@ export const getBrand = (options: ICourierClientConfiguration) => {
 
 export const createBrand = (options: ICourierClientConfiguration) => {
   return async (
-    params: ICourierBrandParameters
+    params: ICourierBrandParameters,
+    config?: ICourierBrandPostConfig
   ): Promise<ICourierBrand> => {
+    const axiosConfig: AxiosRequestConfig = {
+      headers: {},
+    };
+
+    if (config && config.idempotencyKey) {
+      axiosConfig.headers["Idempotency-Key"] = config.idempotencyKey;
+    }
     const res = await options.httpClient.post<ICourierBrand>(
       `/brands`,
-      params
+      params,
+      axiosConfig
     );
     return res.data;
   };
 };
 
 export const replaceBrand = (options: ICourierClientConfiguration) => {
-  return async (
-    params: ICourierBrandPutParameters
-  ): Promise<ICourierBrand> => {
-    const {id, ...rest} = params;
+  return async (params: ICourierBrandPutParameters): Promise<ICourierBrand> => {
+    const { id, ...rest } = params;
     const res = await options.httpClient.put<ICourierBrand>(
       `/brands/${id}`,
       rest
@@ -58,5 +64,5 @@ export const replaceBrand = (options: ICourierClientConfiguration) => {
 export const deleteBrand = (options: ICourierClientConfiguration) => {
   return async (brandId: string): Promise<void> => {
     await options.httpClient.delete<void>(`/brands/${brandId}`);
-  }
+  };
 };

--- a/src/client.ts
+++ b/src/client.ts
@@ -12,7 +12,7 @@ import {
   ICourierProfilePutResponse,
   ICourierSendConfig,
   ICourierSendParameters,
-  ICourierSendResponse,
+  ICourierSendResponse
 } from "./types";
 
 import {
@@ -20,7 +20,7 @@ import {
   deleteBrand,
   getBrand,
   getBrands,
-  replaceBrand,
+  replaceBrand
 } from "./brands";
 
 const send = (options: ICourierClientConfiguration) => {
@@ -29,7 +29,7 @@ const send = (options: ICourierClientConfiguration) => {
     config?: ICourierSendConfig
   ): Promise<ICourierSendResponse> => {
     const axiosConfig: AxiosRequestConfig = {
-      headers: {},
+      headers: {}
     };
 
     if (config && config.idempotencyKey) {
@@ -45,7 +45,7 @@ const send = (options: ICourierClientConfiguration) => {
         override: params.override,
         preferences: params.preferences,
         profile: params.profile,
-        recipient: params.recipientId,
+        recipient: params.recipientId
       },
       axiosConfig
     );
@@ -69,7 +69,7 @@ const replaceProfile = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.put<ICourierProfilePutResponse>(
       `/profiles/${params.recipientId}`,
       {
-        profile: params.profile,
+        profile: params.profile
       }
     );
     return res.data;
@@ -82,7 +82,7 @@ const mergeProfile = (options: ICourierClientConfiguration) => {
     config?: ICourierProfilePostConfig
   ): Promise<ICourierProfilePostResponse> => {
     const axiosConfig: AxiosRequestConfig = {
-      headers: {},
+      headers: {}
     };
 
     if (config && config.idempotencyKey) {
@@ -91,7 +91,7 @@ const mergeProfile = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.post<ICourierProfilePostResponse>(
       `/profiles/${params.recipientId}`,
       {
-        profile: params.profile,
+        profile: params.profile
       },
       axiosConfig
     );
@@ -123,6 +123,6 @@ export const client = (
     mergeProfile: mergeProfile(options),
     replaceBrand: replaceBrand(options),
     replaceProfile: replaceProfile(options),
-    send: send(options),
+    send: send(options)
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,9 @@
+import { AxiosRequestConfig } from "axios";
+
 export type HttpMethodClient = <T>(
   url: string,
-  body?: object
+  body?: object,
+  config?: AxiosRequestConfig
 ) => Promise<{ data: T }>;
 
 export interface IHttpClient {
@@ -8,7 +11,7 @@ export interface IHttpClient {
   patch: HttpMethodClient;
   put: HttpMethodClient;
   get: HttpMethodClient;
-  delete: HttpMethodClient
+  delete: HttpMethodClient;
 }
 
 export interface ICourierClientOptions {
@@ -32,6 +35,10 @@ export interface ICourierSendParameters {
   override?: object;
 }
 
+export interface ICourierSendConfig {
+  idempotencyKey?: string;
+}
+
 export interface ICourierSendResponse {
   messageId: string;
 }
@@ -52,6 +59,10 @@ export interface ICourierProfilePutResponse {
 export interface ICourierProfilePostParameters {
   recipientId: string;
   profile: object;
+}
+
+export interface ICourierProfilePostConfig {
+  idempotencyKey?: string;
 }
 
 export interface ICourierProfilePostResponse {
@@ -133,6 +144,10 @@ export interface ICourierBrandParameters {
   snippets?: ICourierBrandSnippets;
 }
 
+export interface ICourierBrandPostConfig {
+  idempotencyKey?: string;
+}
+
 export interface ICourierBrandPutParameters extends ICourierBrandParameters {
   id: string;
 }
@@ -153,34 +168,29 @@ export interface ICourierProfilePreferences {
 }
 
 export interface ICourierClient {
-  send: (params: ICourierSendParameters) => Promise<ICourierSendResponse>;
-  getMessage: (
-    messageId: string
-  ) => Promise<ICourierMessageGetResponse>;
+  send: (
+    params: ICourierSendParameters,
+    config?: ICourierSendConfig
+  ) => Promise<ICourierSendResponse>;
+  getMessage: (messageId: string) => Promise<ICourierMessageGetResponse>;
   replaceProfile: (
     params: ICourierProfilePutParameters
   ) => Promise<ICourierProfilePutResponse>;
   mergeProfile: (
-    params: ICourierProfilePostParameters
+    params: ICourierProfilePostParameters,
+    config?: ICourierProfilePostConfig
   ) => Promise<ICourierProfilePostResponse>;
   getProfile: (
     params: ICourierProfileGetParameters
   ) => Promise<ICourierProfileGetResponse>;
-  getBrands: (
-    params?: {
-      cursor: string
-    }
-  ) => Promise<ICourierBrandGetAllResponse>;
-  getBrand: (
-    brandId: string
-  ) => Promise<ICourierBrand>;
+  getBrands: (params?: {
+    cursor: string;
+  }) => Promise<ICourierBrandGetAllResponse>;
+  getBrand: (brandId: string) => Promise<ICourierBrand>;
   createBrand: (
-    params: ICourierBrandParameters
+    params: ICourierBrandParameters,
+    config?: ICourierBrandPostConfig
   ) => Promise<ICourierBrand>;
-  replaceBrand: (
-    params: ICourierBrandPutParameters
-  ) => Promise<ICourierBrand>;
-  deleteBrand: (
-    brandId: string
-  ) => Promise<void>;
+  replaceBrand: (params: ICourierBrandPutParameters) => Promise<ICourierBrand>;
+  deleteBrand: (brandId: string) => Promise<void>;
 }


### PR DESCRIPTION
## Description of the change

- Added optional config object for `POST` requests. Users can now set an `idempotencyKey` on `POST` request methods which will be written to the `Idempotency-Key` header.
- Added tests
- Updated README.md to include Idempotency section
- Updated unreleased section of Changelog

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
