### PR TITLE
Accept event or eventId and recipient or recipientId and updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ const courier = CourierClient({ authorizationToken: "<AUTH_TOKEN>" }); // get fr
 
 // Example: send a message supporting email & SMS
 const { messageId } = await courier.send({
-  eventId: "<EVENT_ID>", // get from the Courier UI
-  recipientId: "<RECIPIENT_ID>", // usually your system's User ID
+  event: "<EVENT_ID>", // get from the Courier UI
+  recipient: "<RECIPIENT_ID>", // usually your system's User ID
   profile: {
     email: "example@example.com",
     phone_number: "555-228-3890"
@@ -46,8 +46,8 @@ const courier = CourierClient({ authorizationToken: "<AUTH_TOKEN>" });
 async function run() {
   // Example: send a message
   const { messageId } = await courier.send({
-    eventId: "<EVENT_ID>",
-    recipientId: "<RECIPIENT_ID>",
+    event: "<EVENT_ID>",
+    recipient: "<RECIPIENT_ID>",
     profile: {}, // optional
     data: {}, // optional
     brand: "<BRAND_ID>", //optional
@@ -143,7 +143,7 @@ async function run() {
   const { messageId } = await courier.send(
     {
       eventId: "<EVENT_ID>",
-      recipientId: "<RECIPIENT_ID>",
+      recipient: "<RECIPIENT_ID>",
       profile: {
         email: "example@example.com",
         phone_number: "555-867-5309"

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -85,6 +85,25 @@ describe("CourierClient", () => {
         data: {
           example: "EXAMPLE_DATA"
         },
+        event: "EVENT_ID",
+        profile: {
+          sms: "PHONE_NUMBER"
+        },
+        recipient: "RECIPIENT_ID"
+      })
+    ).resolves.toMatchObject(mockSendResponse);
+  });
+
+  test(".send with old params", async () => {
+    const { send } = CourierClient({
+      authorizationToken: "AUTH_TOKEN"
+    });
+
+    await expect(
+      send({
+        data: {
+          example: "EXAMPLE_DATA"
+        },
         eventId: "EVENT_ID",
         profile: {
           sms: "PHONE_NUMBER"

--- a/src/client.ts
+++ b/src/client.ts
@@ -41,11 +41,12 @@ const send = (options: ICourierClientConfiguration) => {
       {
         brand: params.brand,
         data: params.data,
-        event: params.eventId,
+        event: "eventId" in params ? params.eventId : params.event,
         override: params.override,
         preferences: params.preferences,
         profile: params.profile,
-        recipient: params.recipientId
+        recipient:
+          "recipientId" in params ? params.recipientId : params.recipient
       },
       axiosConfig
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,15 +25,19 @@ export interface ICourierClientConfiguration {
 
 // POST /send
 
-export interface ICourierSendParameters {
-  eventId: string;
-  recipientId: string;
+interface ICourierSendBaseParameters {
   data?: object;
   brand?: string;
   preferences?: ICourierProfilePreferences;
   profile?: object;
   override?: object;
 }
+
+export type ICourierSendParameters = (
+  | { event: string; recipient: string }
+  | { eventId: string; recipientId: string }
+) &
+  ICourierSendBaseParameters;
 
 export interface ICourierSendConfig {
   idempotencyKey?: string;


### PR DESCRIPTION
## Description of the change

Updated send method to accept `event` and `recipient` to match the API and updated the README to add preference for them. The original `eventId` and `recipientId` still work for backwards compatibility.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
