### PR TITLE
Release patch to address return types and send params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Fixed return types for `PUT` methods that return 204
 - Fixed param types for `client.lists.send()`
 - Fixed return type for `client.lists.findByRecipientId()`
+- Fixed param types for `client.lists.put()`
 
 ## [v1.6.0] - 2020-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Fixed return types for `PUT` methods that return 204
 - Fixed param types for `client.lists.send()`
+- Fixed return type for `client.lists.findByRecipientId()`
 
 ## [v1.6.0] - 2020-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [v1.6.1] - 2020-09-23
+
+### Fixed
+
+- Fixed return types for `PUT` methods that return 204
+- Fixed param types for `client.lists.send()`
+
 ## [v1.6.0] - 2020-09-22
 
 ### Added
@@ -92,7 +99,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.0.1 - 2019-07-12
 
-[unreleased]: https://github.com/trycourier/courier-python/compare/v1.6.0...HEAD
+[unreleased]: https://github.com/trycourier/courier-python/compare/v1.6.1...HEAD
+[v1.6.1]: https://github.com/trycourier/courier-python/compare/v1.6.0...v1.6.1
 [v1.6.0]: https://github.com/trycourier/courier-python/compare/v1.5.0...v1.6.0
 [v1.5.0]: https://github.com/trycourier/courier-python/compare/v1.4.0...v1.5.0
 [v1.4.0]: https://github.com/trycourier/courier-python/compare/v1.3.0...v1.4.0

--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ const { messageId } = await courier.send({
 
 // Example: send a message to a list
 const { messageId } = await courier.lists.send({
-  eventId: "<EVENT_ID>", // get from the Courier UI
-  listId: "<LIST_ID>", // e.g. example.list.id
+  event: "<EVENT_ID>", // get from the Courier UI
+  list: "<LIST_ID>", // e.g. example.list.id
   data: {} // optional variables for merging into templates
 });
 
 // Example: send a message to a pattern
 const { messageId } = await courier.lists.send({
-  eventId: "<EVENT_ID>", // get from the Courier UI
+  event: "<EVENT_ID>", // get from the Courier UI
   pattern: "<PATTERN>", // e.g. example.list.*
   data: {} // optional variables for merging into templates
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/lists.test.ts
+++ b/src/__tests__/lists.test.ts
@@ -53,12 +53,12 @@ describe("CourierLists", () => {
       .onGet(/\/lists\/.*\/subscriptions/)
       .reply(200, mockGetListSubscriptionsResponse);
     mock.onGet(/\/lists\/.*/).reply(200, mockListResponse);
-    mock.onPost(/\/lists\/.*\/subscriptions/).reply(204);
+    mock.onPut(/\/lists\/.*\/subscriptions/).reply(204);
     mock
       .onPut(/\/lists\/.*\/subscriptions\/.*/)
       .reply(200, mockRecipientResponse);
     mock.onPut(/\/lists\/.*\/restore/).reply(204);
-    mock.onPut(/\/lists\/.*/).reply(200, mockListResponse);
+    mock.onPut(/\/lists\/.*/).reply(204);
     mock.onDelete(/\/lists\/.*\/subscriptions\/.*/).reply(204);
     mock.onDelete(/\/lists\/.*/).reply(204);
     mock.onPost("/send/list").reply(200, mockSendResponse);
@@ -125,7 +125,7 @@ describe("CourierLists", () => {
         id: "example.list.id",
         name: "Updated Example List"
       })
-    ).resolves.toMatchObject(mockListResponse);
+    ).resolves.toBeUndefined();
   });
 
   test(".delete", async () => {
@@ -186,7 +186,7 @@ describe("CourierLists", () => {
 
     await expect(
       lists.subscribe("example.list.id", "ABCD1234")
-    ).resolves.toMatchObject(mockRecipientResponse);
+    ).resolves.toBeUndefined();
   });
 
   test(".unsubscribe", async () => {

--- a/src/__tests__/lists.test.ts
+++ b/src/__tests__/lists.test.ts
@@ -74,7 +74,7 @@ describe("CourierLists", () => {
       data: {
         example: "EXAMPLE_DATA"
       },
-      eventId: "EVENT_ID",
+      event: "EVENT_ID",
       list: "example.list.id"
     };
 
@@ -90,7 +90,7 @@ describe("CourierLists", () => {
       data: {
         example: "EXAMPLE_DATA"
       },
-      eventId: "EVENT_ID",
+      event: "EVENT_ID",
       pattern: "example.list.*"
     };
 

--- a/src/__tests__/lists.test.ts
+++ b/src/__tests__/lists.test.ts
@@ -140,7 +140,6 @@ describe("CourierLists", () => {
 
     await expect(
       lists.put("example.list.id", {
-        id: "example.list.id",
         name: "Updated Example List"
       })
     ).resolves.toBeUndefined();

--- a/src/__tests__/lists.test.ts
+++ b/src/__tests__/lists.test.ts
@@ -4,9 +4,9 @@ import { CourierClient } from "../index";
 
 import {
   ICourierList,
+  ICourierListFindByRecipientIdResponse,
   ICourierListGetAllResponse,
-  ICourierListGetSubscriptionsResponse,
-  ICourierListRecipient
+  ICourierListGetSubscriptionsResponse
 } from "../lists/types";
 
 import {
@@ -33,12 +33,19 @@ const mockGetListsResponse: ICourierListGetAllResponse = {
   }
 };
 
-const mockRecipientResponse: ICourierListRecipient = {
-  recipient: "ABCD1234"
+const mockFindByRecipientIdResponse: ICourierListFindByRecipientIdResponse = {
+  paging: {
+    more: false
+  },
+  results: [mockListResponse]
 };
 
 const mockGetListSubscriptionsResponse: ICourierListGetSubscriptionsResponse = {
-  items: [mockRecipientResponse],
+  items: [
+    {
+      recipient: "ABCD1234"
+    }
+  ],
   paging: {
     more: false
   }
@@ -48,21 +55,32 @@ describe("CourierLists", () => {
   let mock: MockAdapter;
   beforeEach(() => {
     mock = new MockAdapter(axios);
+    // GET /lists
     mock.onGet("/lists").reply(200, mockGetListsResponse);
+    // GET /lists/{list_id}/subscriptions
     mock
       .onGet(/\/lists\/.*\/subscriptions/)
       .reply(200, mockGetListSubscriptionsResponse);
+    // GET /lists/{list_id}
     mock.onGet(/\/lists\/.*/).reply(200, mockListResponse);
+    // PUT /lists/{list_id}/subscriptions
     mock.onPut(/\/lists\/.*\/subscriptions/).reply(204);
-    mock
-      .onPut(/\/lists\/.*\/subscriptions\/.*/)
-      .reply(200, mockRecipientResponse);
+    // PUT /lists/{list_id}/subscriptions/{recipient_id}
+    mock.onPut(/\/lists\/.*\/subscriptions\/.*/).reply(204);
+    // PUT /lists/{list_id}/restore
     mock.onPut(/\/lists\/.*\/restore/).reply(204);
+    // PUT /lists/{list_id}
     mock.onPut(/\/lists\/.*/).reply(204);
+    // DELETE /lists/{list_id}/subscriptions/{recipient_id}
     mock.onDelete(/\/lists\/.*\/subscriptions\/.*/).reply(204);
+    // DELETE /lists/{list_id}
     mock.onDelete(/\/lists\/.*/).reply(204);
+    // POST /send/list
     mock.onPost("/send/list").reply(200, mockSendResponse);
-    mock.onGet(/\/profiles\/.*\/lists/).reply(200, mockGetListsResponse);
+    // GET /profiles/{recipient_id}/lists
+    mock
+      .onGet(/\/profiles\/.*\/lists/)
+      .reply(200, mockFindByRecipientIdResponse);
   });
 
   test(".send with List", async () => {
@@ -164,21 +182,6 @@ describe("CourierLists", () => {
     ).resolves.toBeUndefined();
   });
 
-  test(".putSubscriptions with Idempotency Key", async () => {
-    const { lists } = CourierClient({
-      authorizationToken: "AUTH_TOKEN"
-    });
-
-    mock.onPost(/\/lists\/.*\/subscriptions/).reply(async (config) => {
-      expect(config.headers["Idempotency-Key"]).toBe("IDEMPOTENCY_KEY_UUID");
-      return [204];
-    });
-
-    await lists.putSubscriptions("example.list.id", ["ABCD1234"], {
-      idempotencyKey: "IDEMPOTENCY_KEY_UUID"
-    });
-  });
-
   test(".subscribe", async () => {
     const { lists } = CourierClient({
       authorizationToken: "AUTH_TOKEN"
@@ -206,6 +209,6 @@ describe("CourierLists", () => {
 
     await expect(
       lists.findByRecipientId("RECIPIENT_ID")
-    ).resolves.toMatchObject(mockGetListsResponse);
+    ).resolves.toMatchObject(mockFindByRecipientIdResponse);
   });
 });

--- a/src/lists/index.ts
+++ b/src/lists/index.ts
@@ -13,7 +13,8 @@ import {
   ICourierListGetAllParams,
   ICourierListGetAllResponse,
   ICourierListGetSubscriptionsParams,
-  ICourierListGetSubscriptionsResponse
+  ICourierListGetSubscriptionsResponse,
+  ICourierListPutParams
 } from "./types";
 
 const list = (options: ICourierClientConfiguration) => {
@@ -37,8 +38,11 @@ const get = (options: ICourierClientConfiguration) => {
 
 const put = (options: ICourierClientConfiguration) => {
   // tslint:disable-next-line: no-shadowed-variable
-  return async (listId: string, list: ICourierList): Promise<void> => {
-    await options.httpClient.put<void>(`/lists/${listId}`, list);
+  return async (
+    listId: string,
+    params: ICourierListPutParams
+  ): Promise<void> => {
+    await options.httpClient.put<void>(`/lists/${listId}`, params);
   };
 };
 

--- a/src/lists/index.ts
+++ b/src/lists/index.ts
@@ -38,12 +38,8 @@ const get = (options: ICourierClientConfiguration) => {
 
 const put = (options: ICourierClientConfiguration) => {
   // tslint:disable-next-line: no-shadowed-variable
-  return async (listId: string, list: ICourierList): Promise<ICourierList> => {
-    const res = await options.httpClient.put<ICourierList>(
-      `/lists/${listId}`,
-      list
-    );
-    return res.data;
+  return async (listId: string, list: ICourierList): Promise<void> => {
+    await options.httpClient.put<void>(`/lists/${listId}`, list);
   };
 };
 
@@ -95,14 +91,10 @@ const putSubscriptions = (options: ICourierClientConfiguration) => {
 };
 
 const subscribe = (options: ICourierClientConfiguration) => {
-  return async (
-    listId: string,
-    recipientId: string
-  ): Promise<ICourierListRecipient> => {
-    const res = await options.httpClient.put<ICourierListRecipient>(
+  return async (listId: string, recipientId: string): Promise<void> => {
+    await options.httpClient.put<void>(
       `/lists/${listId}/subscriptions/${recipientId}`
     );
-    return res.data;
   };
 };
 

--- a/src/lists/index.ts
+++ b/src/lists/index.ts
@@ -9,12 +9,11 @@ import {
   ICourierClientLists,
   ICourierList,
   ICourierListFindByRecipientIdParams,
+  ICourierListFindByRecipientIdResponse,
   ICourierListGetAllParams,
   ICourierListGetAllResponse,
   ICourierListGetSubscriptionsParams,
-  ICourierListGetSubscriptionsResponse,
-  ICourierListPostConfig,
-  ICourierListRecipient
+  ICourierListGetSubscriptionsResponse
 } from "./types";
 
 const list = (options: ICourierClientConfiguration) => {
@@ -68,25 +67,10 @@ const getSubscriptions = (options: ICourierClientConfiguration) => {
 };
 
 const putSubscriptions = (options: ICourierClientConfiguration) => {
-  return async (
-    listId: string,
-    recipients: string[],
-    config?: ICourierListPostConfig
-  ): Promise<void> => {
-    const axiosConfig: AxiosRequestConfig = {
-      headers: {}
-    };
-
-    if (config && config.idempotencyKey) {
-      axiosConfig.headers["Idempotency-Key"] = config.idempotencyKey;
-    }
-    await options.httpClient.put<void>(
-      `/lists/${listId}/subscriptions`,
-      {
-        recipients
-      },
-      axiosConfig
-    );
+  return async (listId: string, recipients: string[]): Promise<void> => {
+    await options.httpClient.put<void>(`/lists/${listId}/subscriptions`, {
+      recipients
+    });
   };
 };
 
@@ -110,11 +94,10 @@ const findByRecipientId = (options: ICourierClientConfiguration) => {
   return async (
     recipientId: string,
     params?: ICourierListFindByRecipientIdParams
-  ): Promise<ICourierListGetAllResponse> => {
-    const res = await options.httpClient.get<ICourierListGetAllResponse>(
-      `/profiles/${recipientId}/lists`,
-      params
-    );
+  ): Promise<ICourierListFindByRecipientIdResponse> => {
+    const res = await options.httpClient.get<
+      ICourierListFindByRecipientIdResponse
+    >(`/profiles/${recipientId}/lists`, params);
     return res.data;
   };
 };

--- a/src/lists/types.ts
+++ b/src/lists/types.ts
@@ -31,10 +31,6 @@ export interface ICourierListRecipient {
   created?: string;
 }
 
-export interface ICourierListPostConfig {
-  idempotencyKey?: string;
-}
-
 export interface ICourierListGetSubscriptionsResponse {
   paging: ICourierPaging;
   items: ICourierListRecipient[];
@@ -44,12 +40,17 @@ export interface ICourierListFindByRecipientIdParams {
   curser?: string;
 }
 
+export interface ICourierListFindByRecipientIdResponse {
+  paging: ICourierPaging;
+  results: ICourierList[];
+}
+
 export interface ICourierClientLists {
   delete: (listId: string) => Promise<void>;
   findByRecipientId: (
     recipientId: string,
     params?: ICourierListFindByRecipientIdParams
-  ) => Promise<ICourierListGetAllResponse>;
+  ) => Promise<ICourierListFindByRecipientIdResponse>;
   get: (listId: string) => Promise<ICourierList>;
   getSubscriptions: (
     listId: string,
@@ -59,11 +60,7 @@ export interface ICourierClientLists {
     params?: ICourierListGetAllParams
   ) => Promise<ICourierListGetAllResponse>;
   put: (listId: string, list: ICourierList) => Promise<void>;
-  putSubscriptions: (
-    listId: string,
-    recipients: string[],
-    config?: ICourierListPostConfig
-  ) => Promise<void>;
+  putSubscriptions: (listId: string, recipients: string[]) => Promise<void>;
   restore: (listId: string) => Promise<void>;
   send: (
     params: ICourierSendListOrPatternParams,

--- a/src/lists/types.ts
+++ b/src/lists/types.ts
@@ -12,6 +12,10 @@ export interface ICourierList {
   updated?: number;
 }
 
+export interface ICourierListPutParams {
+  name: string;
+}
+
 export interface ICourierListGetAllParams {
   cursor?: string;
   pattern?: string;
@@ -59,7 +63,7 @@ export interface ICourierClientLists {
   list: (
     params?: ICourierListGetAllParams
   ) => Promise<ICourierListGetAllResponse>;
-  put: (listId: string, list: ICourierList) => Promise<void>;
+  put: (listId: string, parms: ICourierListPutParams) => Promise<void>;
   putSubscriptions: (listId: string, recipients: string[]) => Promise<void>;
   restore: (listId: string) => Promise<void>;
   send: (

--- a/src/lists/types.ts
+++ b/src/lists/types.ts
@@ -58,7 +58,7 @@ export interface ICourierClientLists {
   list: (
     params?: ICourierListGetAllParams
   ) => Promise<ICourierListGetAllResponse>;
-  put: (listId: string, list: ICourierList) => Promise<ICourierList>;
+  put: (listId: string, list: ICourierList) => Promise<void>;
   putSubscriptions: (
     listId: string,
     recipients: string[],
@@ -69,9 +69,6 @@ export interface ICourierClientLists {
     params: ICourierSendListOrPatternParams,
     config?: ICourierSendConfig
   ) => Promise<ICourierSendResponse>;
-  subscribe: (
-    listId: string,
-    recipientId: string
-  ) => Promise<ICourierListRecipient>;
+  subscribe: (listId: string, recipientId: string) => Promise<void>;
   unsubscribe: (listId: string, recipientId: string) => Promise<void>;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,7 +46,7 @@ export interface ICourierSendResponse {
 }
 
 export interface ICourierSendListOrPatternParams {
-  eventId: string;
+  event: string;
   data?: object;
   brand?: string;
   override?: object;


### PR DESCRIPTION
## Description of the change

Fix return types for `PUT` list methods that return 204.
Fix the param type for `list.send()`

## Type of change
- [X] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [X] Lint rules pass locally
- [X] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
