### PR TITLE
Add support for Basic Auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+### Added
+- Support for Basic Auth Scheme by @tk26
+
 ## [v1.7.1] - 2021-02-01
 ### Fixed
 - Fix the notification(s) typo [#28](https://github.com/trycourier/courier-node/pull/28)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,13 @@ const { messageId } = await courier.lists.send({
 
 ## Environment Variables
 
-`courier-node` supports credential storage in environment variables. If no `authorizationToken` is provided when instantiating the Courier client (e.g., `const courier = CourierClient();`), the value in the `COURIER_AUTH_TOKEN` env var will be used.
+`courier-node` supports credential storage in environment variables.
+
+Bearer Auth Scheme - If no `authorizationToken` is provided when instantiating the Courier client (e.g., `const courier = CourierClient();`), the value in the `COURIER_AUTH_TOKEN` env var will be used. 
+
+Basic Auth Scheme - If no `username` and `password` combination is provided when instantiating the Courier client, the values in the `COURIER_AUTH_USERNAME` and `COURIER_AUTH_PASSWORD` env vars will be used.
+
+Note: Bearer Auth Scheme takes a precendence over Basic Auth. So if the details for both are provided, Bearer Auth scheme would be used.
 
 If you need to use a base url other than the default https://api.courier.com, you can set it using the `COURIER_BASE_URL` env var.
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface IHttpClient {
 export interface ICourierClientOptions {
   baseUrl?: string;
   authorizationToken?: string;
+  username?: string;
+  password?: string;
 }
 
 export interface ICourierClientConfiguration {


### PR DESCRIPTION
## Description of the change

> Add Support for Basic Auth Scheme, Bearer taking precedence but fallback with Basic, Support username and password through env vars

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> None

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
