### PR TITLE
[C-2418] updates preference interface to accept new options

### DIFF
--- a/src/lists/types.ts
+++ b/src/lists/types.ts
@@ -1,4 +1,7 @@
-import { ICourierNotificationPreferences } from "../preferences/types";
+import {
+  ICourierNotificationPreferences,
+  IRecipientPreferences
+} from "../preferences/types";
 import {
   ICourierPaging,
   ICourierSendConfig,
@@ -15,6 +18,10 @@ export interface ICourierList {
 
 export interface ICourierListPutParams {
   name: string;
+  preferences?: {
+    notifications: IRecipientPreferences;
+    categories?: IRecipientPreferences;
+  };
 }
 
 export interface ICourierListGetAllParams {

--- a/src/preferences/index.ts
+++ b/src/preferences/index.ts
@@ -30,12 +30,16 @@ const get = (options: ICourierClientConfiguration) => {
 const put = (options: ICourierClientConfiguration) => {
   return async (
     recipientId: string,
-    params: IRecipientPreferences
+    params?: IRecipientPreferences
   ): Promise<ICourierPreferencesPutResponse> => {
+    const categories = params?.categories ?? {};
+    const notifications = params?.notifications ?? {};
+
     const res = await options.httpClient.put<ICourierPreferencesPutResponse>(
       `/preferences/${recipientId}`,
       {
-        notifications: params.notifications
+        categories,
+        notifications
       }
     );
     return res.data;

--- a/src/preferences/types.ts
+++ b/src/preferences/types.ts
@@ -1,6 +1,26 @@
+export type RuleType = "snooze";
+
+export interface IRule<T extends RuleType> {
+  type: T;
+}
+
+export interface ISnoozeRule extends IRule<"snooze"> {
+  start?: string;
+  until: string;
+}
+
+export type ChannelClassification = "direct_message" | "email" | "push";
+
+export type Rule = ISnoozeRule;
+
+export type PreferenceStatus = "OPTED_OUT" | "OPTED_IN";
 export interface ICourierNotificationPreferences {
   [id: string]: {
     status: PreferenceStatus;
+    rules?: Rule[];
+    channel_preferences?: Array<{
+      channel: ChannelClassification;
+    }>;
   };
 }
 
@@ -18,8 +38,6 @@ export interface ICourierPreferencesListResponse {
     notifications?: Array<{}>;
   }>;
 }
-
-export type PreferenceStatus = "OPTED_OUT" | "OPTED_IN";
 
 export interface IRecipientPreferences {
   categories?: ICourierNotificationPreferences;


### PR DESCRIPTION
## Description of the change
- Updates preference interface to accept following to match with [rest endpoint](https://docs.courier.com/reference/preferences-api#getpreferencesbyrecipientid).  
    - `rules` 
    - `channel_preferences`
```typescript

{
  "notifications": { 
     notifications: {
       "<notification_id>":  {
          status: PreferenceStatus;
          rules?: Rule[];
          channel_preferences?: Array<{channel: ChannelClassification}>;
      }
    }
  }
}
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

