### PR TITLE
[C-2417] implements post /profiles/:recipientId/lists endpoints

### DIFF
--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -1,0 +1,74 @@
+import axios from "axios";
+import MockAdapter from "axios-mock-adapter";
+import { CourierClient } from "../index";
+import { ICourierList } from "../lists/types";
+import { ICourierProfilePostResponse, List } from "../types";
+
+const mockGetProfileListResponse: ICourierList[] = [
+  {
+    id: "example.list1",
+    name: "Courier Feature update list"
+  }
+];
+
+const mockPostResponse: ICourierProfilePostResponse = {
+  status: "SUCCESS"
+};
+
+const additionalMocklists: List[] = [
+  {
+    listId: "example.list1",
+    name: "Courier Feature updates",
+    preferences: {
+      notifications: {
+        "1231123": {
+          status: "OPTED_IN"
+        }
+      }
+    }
+  },
+  {
+    listId: "example.list2",
+    name: "Courier API updates",
+    preferences: {
+      notifications: {
+        "1231123": {
+          status: "OPTED_IN"
+        }
+      }
+    }
+  }
+];
+
+describe("Courier Recipient Profile", () => {
+  let mock: MockAdapter;
+
+  beforeEach(() => {
+    mock = new MockAdapter(axios);
+    mock.onGet(/\/profiles\/.*\/lists/).reply(200, mockGetProfileListResponse);
+    mock.onPost(/\/profiles\/.*\/lists/).reply(200, mockPostResponse);
+  });
+
+  test("should return lists associated with recipient", async () => {
+    const { getRecipientSubscriptions } = CourierClient({
+      authorizationToken: "AUTH_TOKEN"
+    });
+
+    await expect(
+      getRecipientSubscriptions({ recipientId: "12345" })
+    ).resolves.toMatchObject(mockGetProfileListResponse);
+  });
+
+  test("should subscribe recipient to provided lists", async () => {
+    const { addRecipientToLists } = CourierClient({
+      authorizationToken: "AUTH_TOKEN"
+    });
+
+    await expect(
+      addRecipientToLists({
+        lists: additionalMocklists,
+        recipientId: "12345"
+      })
+    ).resolves.toMatchObject(mockPostResponse);
+  });
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,21 +1,5 @@
 import { AxiosRequestConfig } from "axios";
 import {
-  ICourierClient,
-  ICourierClientConfiguration,
-  ICourierMessageGetResponse,
-  ICourierProfileGetParameters,
-  ICourierProfileGetResponse,
-  ICourierProfilePostConfig,
-  ICourierProfilePostParameters,
-  ICourierProfilePostResponse,
-  ICourierProfilePutParameters,
-  ICourierProfilePutResponse,
-  ICourierSendConfig,
-  ICourierSendParameters,
-  ICourierSendResponse
-} from "./types";
-
-import {
   createBrand,
   deleteBrand,
   getBrand,
@@ -24,6 +8,22 @@ import {
 } from "./brands";
 import { lists } from "./lists";
 import { preferences } from "./preferences";
+import {
+  addRecipientToLists,
+  getProfile,
+  getRecipientSubscriptions,
+  mergeProfile,
+  replaceProfile
+} from "./profile";
+
+import {
+  ICourierClient,
+  ICourierClientConfiguration,
+  ICourierMessageGetResponse,
+  ICourierSendConfig,
+  ICourierSendParameters,
+  ICourierSendResponse
+} from "./types";
 
 const send = (options: ICourierClientConfiguration) => {
   return async (
@@ -64,64 +64,18 @@ const getMessage = (options: ICourierClientConfiguration) => {
   };
 };
 
-const replaceProfile = (options: ICourierClientConfiguration) => {
-  return async (
-    params: ICourierProfilePutParameters
-  ): Promise<ICourierProfilePutResponse> => {
-    const res = await options.httpClient.put<ICourierProfilePutResponse>(
-      `/profiles/${params.recipientId}`,
-      {
-        profile: params.profile
-      }
-    );
-    return res.data;
-  };
-};
-
-const mergeProfile = (options: ICourierClientConfiguration) => {
-  return async (
-    params: ICourierProfilePostParameters,
-    config?: ICourierProfilePostConfig
-  ): Promise<ICourierProfilePostResponse> => {
-    const axiosConfig: AxiosRequestConfig = {
-      headers: {}
-    };
-
-    if (config && config.idempotencyKey) {
-      axiosConfig.headers["Idempotency-Key"] = config.idempotencyKey;
-    }
-    const res = await options.httpClient.post<ICourierProfilePostResponse>(
-      `/profiles/${params.recipientId}`,
-      {
-        profile: params.profile
-      },
-      axiosConfig
-    );
-    return res.data;
-  };
-};
-
-const getProfile = (options: ICourierClientConfiguration) => {
-  return async (
-    params: ICourierProfileGetParameters
-  ): Promise<ICourierProfileGetResponse> => {
-    const res = await options.httpClient.get<ICourierProfileGetResponse>(
-      `/profiles/${params.recipientId}`
-    );
-    return res.data;
-  };
-};
-
 export const client = (
   options: ICourierClientConfiguration
 ): ICourierClient => {
   return {
+    addRecipientToLists: addRecipientToLists(options),
     createBrand: createBrand(options),
     deleteBrand: deleteBrand(options),
     getBrand: getBrand(options),
     getBrands: getBrands(options),
     getMessage: getMessage(options),
     getProfile: getProfile(options),
+    getRecipientSubscriptions: getRecipientSubscriptions(options),
     lists: lists(options),
     mergeProfile: mergeProfile(options),
     preferences: preferences(options),

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,0 +1,93 @@
+import { AxiosRequestConfig } from "axios";
+import { ICourierList } from "./lists/types";
+import {
+  ICourierClientConfiguration,
+  ICourierProfileGetParameters,
+  ICourierProfileGetResponse,
+  ICourierProfileListsPostParameters,
+  ICourierProfilePostConfig,
+  ICourierProfilePostParameters,
+  ICourierProfilePostResponse,
+  ICourierProfilePutParameters,
+  ICourierProfilePutResponse
+} from "./types";
+
+export const replaceProfile = (options: ICourierClientConfiguration) => {
+  return async (
+    params: ICourierProfilePutParameters
+  ): Promise<ICourierProfilePutResponse> => {
+    const res = await options.httpClient.put<ICourierProfilePutResponse>(
+      `/profiles/${params.recipientId}`,
+      {
+        profile: params.profile
+      }
+    );
+    return res.data;
+  };
+};
+
+export const mergeProfile = (options: ICourierClientConfiguration) => {
+  return async (
+    params: ICourierProfilePostParameters,
+    config?: ICourierProfilePostConfig
+  ): Promise<ICourierProfilePostResponse> => {
+    const axiosConfig: AxiosRequestConfig = {
+      headers: {}
+    };
+
+    if (config && config.idempotencyKey) {
+      axiosConfig.headers["Idempotency-Key"] = config.idempotencyKey;
+    }
+    const res = await options.httpClient.post<ICourierProfilePostResponse>(
+      `/profiles/${params.recipientId}`,
+      {
+        profile: params.profile
+      },
+      axiosConfig
+    );
+    return res.data;
+  };
+};
+
+export const getProfile = (options: ICourierClientConfiguration) => {
+  return async (
+    params: ICourierProfileGetParameters
+  ): Promise<ICourierProfileGetResponse> => {
+    const res = await options.httpClient.get<ICourierProfileGetResponse>(
+      `/profiles/${params.recipientId}`
+    );
+    return res.data;
+  };
+};
+
+export const getRecipientSubscriptions = (
+  options: ICourierClientConfiguration
+) => {
+  return async (
+    params: ICourierProfileGetParameters
+  ): Promise<ICourierList[]> => {
+    const res = await options.httpClient.get<ICourierList[]>(
+      `/profiles/${params.recipientId}/lists`
+    );
+    return res.data;
+  };
+};
+
+export const addRecipientToLists = (options: ICourierClientConfiguration) => {
+  return async (
+    params: ICourierProfileListsPostParameters
+  ): Promise<ICourierProfilePostResponse> => {
+    const axiosConfig: AxiosRequestConfig = {
+      headers: {}
+    };
+
+    const res = await options.httpClient.post<ICourierProfilePostResponse>(
+      `/profiles/${params.recipientId}/lists`,
+      {
+        lists: params.lists
+      },
+      axiosConfig
+    );
+    return res.data;
+  };
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
 import { AxiosRequestConfig } from "axios";
 
-import { ICourierClientLists } from "./lists/types";
+import { ICourierClientLists, ICourierList } from "./lists/types";
 import {
   ICourierClientPreferences,
   IRecipientPreferences
@@ -81,6 +81,16 @@ export interface ICourierProfilePutResponse {
 export interface ICourierProfilePostParameters {
   recipientId: string;
   profile: object;
+}
+// POST /profiles/{id}/lists
+export type List = Omit<ICourierList, "id"> & {
+  listId: string;
+  preferences?: IRecipientPreferences;
+};
+
+export interface ICourierProfileListsPostParameters {
+  recipientId: string;
+  lists: List[];
 }
 
 export interface ICourierProfilePostConfig {
@@ -180,31 +190,37 @@ export interface ICourierBrandGetAllResponse {
 }
 
 export interface ICourierClient {
-  send: (
-    params: ICourierSendParameters,
-    config?: ICourierSendConfig
-  ) => Promise<ICourierSendResponse>;
-  getMessage: (messageId: string) => Promise<ICourierMessageGetResponse>;
-  replaceProfile: (
-    params: ICourierProfilePutParameters
-  ) => Promise<ICourierProfilePutResponse>;
-  mergeProfile: (
-    params: ICourierProfilePostParameters,
-    config?: ICourierProfilePostConfig
+  addRecipientToLists: (
+    params: ICourierProfileListsPostParameters
   ) => Promise<ICourierProfilePostResponse>;
-  getProfile: (
-    params: ICourierProfileGetParameters
-  ) => Promise<ICourierProfileGetResponse>;
-  getBrands: (params?: {
-    cursor: string;
-  }) => Promise<ICourierBrandGetAllResponse>;
-  getBrand: (brandId: string) => Promise<ICourierBrand>;
   createBrand: (
     params: ICourierBrandParameters,
     config?: ICourierBrandPostConfig
   ) => Promise<ICourierBrand>;
-  replaceBrand: (params: ICourierBrandPutParameters) => Promise<ICourierBrand>;
   deleteBrand: (brandId: string) => Promise<void>;
+  getBrand: (brandId: string) => Promise<ICourierBrand>;
+  getBrands: (params?: {
+    cursor: string;
+  }) => Promise<ICourierBrandGetAllResponse>;
+  getMessage: (messageId: string) => Promise<ICourierMessageGetResponse>;
+  getProfile: (
+    params: ICourierProfileGetParameters
+  ) => Promise<ICourierProfileGetResponse>;
+  getRecipientSubscriptions: (
+    params: ICourierProfileGetParameters
+  ) => Promise<ICourierList[]>;
   lists: ICourierClientLists;
+  mergeProfile: (
+    params: ICourierProfilePostParameters,
+    config?: ICourierProfilePostConfig
+  ) => Promise<ICourierProfilePostResponse>;
   preferences: ICourierClientPreferences;
+  replaceBrand: (params: ICourierBrandPutParameters) => Promise<ICourierBrand>;
+  replaceProfile: (
+    params: ICourierProfilePutParameters
+  ) => Promise<ICourierProfilePutResponse>;
+  send: (
+    params: ICourierSendParameters,
+    config?: ICourierSendConfig
+  ) => Promise<ICourierSendResponse>;
 }


### PR DESCRIPTION
## Description of the change

Adds support for [subscribing recipients to multiple lists](https://docs.courier.com/reference/profiles-api#postlistsforprofilebyrecipientid)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

