### PR TITLE
[C-2416] adds function to remove all subscriptions for a given recipient

### DIFF
--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -47,6 +47,7 @@ describe("Courier Recipient Profile", () => {
     mock = new MockAdapter(axios);
     mock.onGet(/\/profiles\/.*\/lists/).reply(200, mockGetProfileListResponse);
     mock.onPost(/\/profiles\/.*\/lists/).reply(200, mockPostResponse);
+    mock.onDelete(/\/profiles\/.*\/lists/).reply(200, mockPostResponse);
   });
 
   test("should return lists associated with recipient", async () => {
@@ -67,6 +68,18 @@ describe("Courier Recipient Profile", () => {
     await expect(
       addRecipientToLists({
         lists: additionalMocklists,
+        recipientId: "12345"
+      })
+    ).resolves.toMatchObject(mockPostResponse);
+  });
+
+  test("should remove recipient from all the lists subscription", async () => {
+    const { removeRecipientFromAllLists } = CourierClient({
+      authorizationToken: "AUTH_TOKEN"
+    });
+
+    await expect(
+      removeRecipientFromAllLists({
         recipientId: "12345"
       })
     ).resolves.toMatchObject(mockPostResponse);

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,7 @@ import {
   getProfile,
   getRecipientSubscriptions,
   mergeProfile,
+  removeRecipientFromAllLists,
   replaceProfile
 } from "./profile";
 
@@ -79,6 +80,7 @@ export const client = (
     lists: lists(options),
     mergeProfile: mergeProfile(options),
     preferences: preferences(options),
+    removeRecipientFromAllLists: removeRecipientFromAllLists(options),
     replaceBrand: replaceBrand(options),
     replaceProfile: replaceProfile(options),
     send: send(options)

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -77,16 +77,24 @@ export const addRecipientToLists = (options: ICourierClientConfiguration) => {
   return async (
     params: ICourierProfileListsPostParameters
   ): Promise<ICourierProfilePostResponse> => {
-    const axiosConfig: AxiosRequestConfig = {
-      headers: {}
-    };
-
     const res = await options.httpClient.post<ICourierProfilePostResponse>(
       `/profiles/${params.recipientId}/lists`,
       {
         lists: params.lists
-      },
-      axiosConfig
+      }
+    );
+    return res.data;
+  };
+};
+
+export const removeRecipientFromAllLists = (
+  options: ICourierClientConfiguration
+) => {
+  return async (
+    params: ICourierProfileGetParameters
+  ): Promise<ICourierProfilePostResponse> => {
+    const res = await options.httpClient.delete<ICourierProfilePostResponse>(
+      `/profiles/${params.recipientId}/lists`
     );
     return res.data;
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -215,6 +215,9 @@ export interface ICourierClient {
     config?: ICourierProfilePostConfig
   ) => Promise<ICourierProfilePostResponse>;
   preferences: ICourierClientPreferences;
+  removeRecipientFromAllLists: (
+    params: ICourierProfileGetParameters
+  ) => Promise<ICourierProfilePostResponse>;
   replaceBrand: (params: ICourierBrandPutParameters) => Promise<ICourierBrand>;
   replaceProfile: (
     params: ICourierProfilePutParameters


### PR DESCRIPTION
## Description of the change

Adds [implementation](https://docs.courier.com/reference/profiles-api#deletelistsforprofilebyrecipientid) for deleting all the lists associated with a recipient 

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

