### PR TITLE
[C-2415] adds support to post / add more recipients to a subscription

### DIFF
--- a/src/__tests__/lists.test.ts
+++ b/src/__tests__/lists.test.ts
@@ -74,6 +74,7 @@ describe("CourierLists", () => {
     mock.onPut(/\/lists\/.*\/subscriptions/).reply(204);
     // PUT /lists/{list_id}/subscriptions/{recipient_id}
     mock.onPut(/\/lists\/.*\/subscriptions\/.*/).reply(204);
+    mock.onPost(/\/lists\/.*\/subscriptions/).reply(204);
     // PUT /lists/{list_id}/restore
     mock.onPut(/\/lists\/.*\/restore/).reply(204);
     // PUT /lists/{list_id}
@@ -208,6 +209,16 @@ describe("CourierLists", () => {
 
     await expect(
       lists.putSubscriptions("example.list.id", [mockRecipientWithPreferences])
+    ).resolves.toBeUndefined();
+  });
+
+  test(".postSubscriptions", async () => {
+    const { lists } = CourierClient({
+      authorizationToken: "AUTH_TOKEN"
+    });
+
+    await expect(
+      lists.postSubscriptions("example.list.id", [{ recipientId: "ABCD1234" }])
     ).resolves.toBeUndefined();
   });
 

--- a/src/lists/index.ts
+++ b/src/lists/index.ts
@@ -83,6 +83,17 @@ const putSubscriptions = (options: ICourierClientConfiguration) => {
   };
 };
 
+const postSubscriptions = (options: ICourierClientConfiguration) => {
+  return async (
+    listId: string,
+    recipients: ICourierPutSubscriptionsRecipient[]
+  ): Promise<void> => {
+    await options.httpClient.post<void>(`/lists/${listId}/subscriptions`, {
+      recipients
+    });
+  };
+};
+
 const subscribe = (options: ICourierClientConfiguration) => {
   return async (
     listId: string,
@@ -149,6 +160,7 @@ export const lists = (
     get: get(options),
     getSubscriptions: getSubscriptions(options),
     list: list(options),
+    postSubscriptions: postSubscriptions(options),
     put: put(options),
     putSubscriptions: putSubscriptions(options),
     restore: restore(options),

--- a/src/lists/types.ts
+++ b/src/lists/types.ts
@@ -82,6 +82,10 @@ export interface ICourierClientLists {
   list: (
     params?: ICourierListGetAllParams
   ) => Promise<ICourierListGetAllResponse>;
+  postSubscriptions: (
+    listId: string,
+    recipients: ICourierPutSubscriptionsRecipient[]
+  ) => Promise<void>;
   put: (listId: string, parms: ICourierListPutParams) => Promise<void>;
   putSubscriptions: (
     listId: string,


### PR DESCRIPTION
## Description of the change
- adds support to [post / add more recipients](https://docs.courier.com/reference/lists-api#updatelistsubscriptions) to a subscription 


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

