### PR TITLE
Add support for DELETE /profiles/{recipient_id}

### DIFF
--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -48,6 +48,17 @@ describe("Courier Recipient Profile", () => {
     mock.onGet(/\/profiles\/.*\/lists/).reply(200, mockGetProfileListResponse);
     mock.onPost(/\/profiles\/.*\/lists/).reply(200, mockPostResponse);
     mock.onDelete(/\/profiles\/.*\/lists/).reply(200, mockPostResponse);
+    mock.onDelete(/\/profiles\/.*/).reply(200);
+  });
+
+  test("should delete profile", async () => {
+    const { deleteProfile } = CourierClient({
+      authorizationToken: "AUTH_TOKEN"
+    });
+
+    await expect(
+      deleteProfile({ recipientId: "12345" })
+    ).resolves.toBeUndefined();
   });
 
   test("should return lists associated with recipient", async () => {

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,7 @@ import { notifications } from "./notifications";
 import { preferences } from "./preferences";
 import {
   addRecipientToLists,
+  deleteProfile,
   getProfile,
   getRecipientSubscriptions,
   mergeProfile,
@@ -79,6 +80,7 @@ export const client = (
     getBrand: getBrand(options),
     getBrands: getBrands(options),
     getMessage: getMessage(options),
+    deleteProfile: deleteProfile(options),
     getProfile: getProfile(options),
     getRecipientSubscriptions: getRecipientSubscriptions(options),
     lists: lists(options),

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -4,6 +4,7 @@ import {
   ICourierClientConfiguration,
   ICourierProfileGetParameters,
   ICourierProfileGetResponse,
+  ICourierProfileDeleteParameters,
   ICourierProfileListsPostParameters,
   ICourierProfilePostConfig,
   ICourierProfilePostParameters,
@@ -57,6 +58,12 @@ export const getProfile = (options: ICourierClientConfiguration) => {
       `/profiles/${params.recipientId}`
     );
     return res.data;
+  };
+};
+
+export const deleteProfile = (options: ICourierClientConfiguration) => {
+  return async (params: ICourierProfileDeleteParameters): Promise<void> => {
+    await options.httpClient.delete<void>(`/profiles/${params.recipientId}`);
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,6 +135,12 @@ export interface ICourierMessageGetResponse {
   status: string;
 }
 
+// DELETE /profiles/{recipient_id}
+
+export interface ICourierProfileDeleteParameters {
+  recipientId: string;
+}
+
 interface ICourierBrandSettings {
   colors?: {
     primary: string;
@@ -209,6 +215,7 @@ export interface ICourierClient {
   getProfile: (
     params: ICourierProfileGetParameters
   ) => Promise<ICourierProfileGetResponse>;
+  deleteProfile: (params: ICourierProfileDeleteParameters) => Promise<void>;
   getRecipientSubscriptions: (
     params: ICourierProfileGetParameters
   ) => Promise<ICourierList[]>;


### PR DESCRIPTION
## Description of the change

Implements the `DELETE /profiles/{recipient_id}` API.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

N/A

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
