### PR TITLE
[C-4363] fixes type definition for recipient list subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [v3.0.0] - 2021-11-02
+
+- fixes type definition for `getRecipientSubscriptions`
+
 ## [v2.8.0] - 2021-10-29
 
 - adds GET /messages/{messageId}/output API
@@ -173,7 +177,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.0.1 - 2019-07-12
 
-[unreleased]: https://github.com/trycourier/courier-node/compare/v2.8.0...HEAD
+[unreleased]: https://github.com/trycourier/courier-node/compare/v3.0.0...HEAD
+[v3.0.0]: https://github.com/trycourier/courier-node/compare/v2.8.0...v3.0.0
 [v2.8.0]: https://github.com/trycourier/courier-node/compare/v2.7.0...v2.8.0
 [v2.7.0]: https://github.com/trycourier/courier-node/compare/v2.6.0...v2.7.0
 [v2.6.0]: https://github.com/trycourier/courier-node/compare/v2.4.0...v2.6.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "2.8.0",
+  "version": "3.0.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -1,18 +1,24 @@
 import axios from "axios";
 import MockAdapter from "axios-mock-adapter";
 import { CourierClient } from "../index";
-import { ICourierList } from "../lists/types";
+import { ICourierRecipientSubscriptionsResponse } from "../lists/types";
 import { ICourierProfilePostResponse, List } from "../types";
 
-const mockGetProfileListResponse: ICourierList[] = [
-  {
-    id: "example.list1",
-    name: "Courier Feature update list"
-  }
-];
+const mockGetProfileListResponse: ICourierRecipientSubscriptionsResponse = {
+  paging: {
+    cursor: "",
+    more: false,
+  },
+  results: [
+    {
+      id: "example.list1",
+      name: "Courier Feature update list",
+    },
+  ],
+};
 
 const mockPostResponse: ICourierProfilePostResponse = {
-  status: "SUCCESS"
+  status: "SUCCESS",
 };
 
 const additionalMocklists: List[] = [
@@ -22,10 +28,10 @@ const additionalMocklists: List[] = [
     preferences: {
       notifications: {
         "1231123": {
-          status: "OPTED_IN"
-        }
-      }
-    }
+          status: "OPTED_IN",
+        },
+      },
+    },
   },
   {
     listId: "example.list2",
@@ -33,11 +39,11 @@ const additionalMocklists: List[] = [
     preferences: {
       notifications: {
         "1231123": {
-          status: "OPTED_IN"
-        }
-      }
-    }
-  }
+          status: "OPTED_IN",
+        },
+      },
+    },
+  },
 ];
 
 describe("Courier Recipient Profile", () => {
@@ -53,7 +59,7 @@ describe("Courier Recipient Profile", () => {
 
   test("should delete profile", async () => {
     const { deleteProfile } = CourierClient({
-      authorizationToken: "AUTH_TOKEN"
+      authorizationToken: "AUTH_TOKEN",
     });
 
     await expect(
@@ -63,7 +69,7 @@ describe("Courier Recipient Profile", () => {
 
   test("should return lists associated with recipient", async () => {
     const { getRecipientSubscriptions } = CourierClient({
-      authorizationToken: "AUTH_TOKEN"
+      authorizationToken: "AUTH_TOKEN",
     });
 
     await expect(
@@ -73,25 +79,25 @@ describe("Courier Recipient Profile", () => {
 
   test("should subscribe recipient to provided lists", async () => {
     const { addRecipientToLists } = CourierClient({
-      authorizationToken: "AUTH_TOKEN"
+      authorizationToken: "AUTH_TOKEN",
     });
 
     await expect(
       addRecipientToLists({
         lists: additionalMocklists,
-        recipientId: "12345"
+        recipientId: "12345",
       })
     ).resolves.toMatchObject(mockPostResponse);
   });
 
   test("should remove recipient from all the lists subscription", async () => {
     const { removeRecipientFromAllLists } = CourierClient({
-      authorizationToken: "AUTH_TOKEN"
+      authorizationToken: "AUTH_TOKEN",
     });
 
     await expect(
       removeRecipientFromAllLists({
-        recipientId: "12345"
+        recipientId: "12345",
       })
     ).resolves.toMatchObject(mockPostResponse);
   });

--- a/src/__tests__/profile.test.ts
+++ b/src/__tests__/profile.test.ts
@@ -7,18 +7,18 @@ import { ICourierProfilePostResponse, List } from "../types";
 const mockGetProfileListResponse: ICourierRecipientSubscriptionsResponse = {
   paging: {
     cursor: "",
-    more: false,
+    more: false
   },
   results: [
     {
       id: "example.list1",
-      name: "Courier Feature update list",
-    },
-  ],
+      name: "Courier Feature update list"
+    }
+  ]
 };
 
 const mockPostResponse: ICourierProfilePostResponse = {
-  status: "SUCCESS",
+  status: "SUCCESS"
 };
 
 const additionalMocklists: List[] = [
@@ -28,10 +28,10 @@ const additionalMocklists: List[] = [
     preferences: {
       notifications: {
         "1231123": {
-          status: "OPTED_IN",
-        },
-      },
-    },
+          status: "OPTED_IN"
+        }
+      }
+    }
   },
   {
     listId: "example.list2",
@@ -39,11 +39,11 @@ const additionalMocklists: List[] = [
     preferences: {
       notifications: {
         "1231123": {
-          status: "OPTED_IN",
-        },
-      },
-    },
-  },
+          status: "OPTED_IN"
+        }
+      }
+    }
+  }
 ];
 
 describe("Courier Recipient Profile", () => {
@@ -59,7 +59,7 @@ describe("Courier Recipient Profile", () => {
 
   test("should delete profile", async () => {
     const { deleteProfile } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
@@ -69,7 +69,7 @@ describe("Courier Recipient Profile", () => {
 
   test("should return lists associated with recipient", async () => {
     const { getRecipientSubscriptions } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
@@ -79,25 +79,25 @@ describe("Courier Recipient Profile", () => {
 
   test("should subscribe recipient to provided lists", async () => {
     const { addRecipientToLists } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
       addRecipientToLists({
         lists: additionalMocklists,
-        recipientId: "12345",
+        recipientId: "12345"
       })
     ).resolves.toMatchObject(mockPostResponse);
   });
 
   test("should remove recipient from all the lists subscription", async () => {
     const { removeRecipientFromAllLists } = CourierClient({
-      authorizationToken: "AUTH_TOKEN",
+      authorizationToken: "AUTH_TOKEN"
     });
 
     await expect(
       removeRecipientFromAllLists({
-        recipientId: "12345",
+        recipientId: "12345"
       })
     ).resolves.toMatchObject(mockPostResponse);
   });

--- a/src/lists/types.ts
+++ b/src/lists/types.ts
@@ -1,12 +1,12 @@
 import {
   ICourierNotificationPreferences,
-  IRecipientPreferences
+  IRecipientPreferences,
 } from "../preferences/types";
 import {
   ICourierPaging,
   ICourierSendConfig,
   ICourierSendListOrPatternParams,
-  ICourierSendResponse
+  ICourierSendResponse,
 } from "../types";
 
 export interface ICourierList {
@@ -14,6 +14,11 @@ export interface ICourierList {
   id: string;
   name: string;
   updated?: number;
+}
+
+export interface ICourierRecipientSubscriptionsResponse {
+  paging: ICourierPaging;
+  results: ICourierList[];
 }
 
 export interface ICourierListPutParams {

--- a/src/lists/types.ts
+++ b/src/lists/types.ts
@@ -1,12 +1,12 @@
 import {
   ICourierNotificationPreferences,
-  IRecipientPreferences,
+  IRecipientPreferences
 } from "../preferences/types";
 import {
   ICourierPaging,
   ICourierSendConfig,
   ICourierSendListOrPatternParams,
-  ICourierSendResponse,
+  ICourierSendResponse
 } from "../types";
 
 export interface ICourierList {

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -1,5 +1,5 @@
 import { AxiosRequestConfig } from "axios";
-import { ICourierList } from "./lists/types";
+import { ICourierRecipientSubscriptionsResponse } from "./lists/types";
 import {
   ICourierClientConfiguration,
   ICourierProfileDeleteParameters,
@@ -10,7 +10,7 @@ import {
   ICourierProfilePostParameters,
   ICourierProfilePostResponse,
   ICourierProfilePutParameters,
-  ICourierProfilePutResponse
+  ICourierProfilePutResponse,
 } from "./types";
 
 export const replaceProfile = (options: ICourierClientConfiguration) => {
@@ -20,7 +20,7 @@ export const replaceProfile = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.put<ICourierProfilePutResponse>(
       `/profiles/${params.recipientId}`,
       {
-        profile: params.profile
+        profile: params.profile,
       }
     );
     return res.data;
@@ -33,7 +33,7 @@ export const mergeProfile = (options: ICourierClientConfiguration) => {
     config?: ICourierProfilePostConfig
   ): Promise<ICourierProfilePostResponse> => {
     const axiosConfig: AxiosRequestConfig = {
-      headers: {}
+      headers: {},
     };
 
     if (config && config.idempotencyKey) {
@@ -42,7 +42,7 @@ export const mergeProfile = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.post<ICourierProfilePostResponse>(
       `/profiles/${params.recipientId}`,
       {
-        profile: params.profile
+        profile: params.profile,
       },
       axiosConfig
     );
@@ -72,10 +72,10 @@ export const getRecipientSubscriptions = (
 ) => {
   return async (
     params: ICourierProfileGetParameters
-  ): Promise<ICourierList[]> => {
-    const res = await options.httpClient.get<ICourierList[]>(
-      `/profiles/${params.recipientId}/lists`
-    );
+  ): Promise<ICourierRecipientSubscriptionsResponse> => {
+    const res = await options.httpClient.get<
+      ICourierRecipientSubscriptionsResponse
+    >(`/profiles/${params.recipientId}/lists`);
     return res.data;
   };
 };
@@ -87,7 +87,7 @@ export const addRecipientToLists = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.post<ICourierProfilePostResponse>(
       `/profiles/${params.recipientId}/lists`,
       {
-        lists: params.lists
+        lists: params.lists,
       }
     );
     return res.data;

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -10,7 +10,7 @@ import {
   ICourierProfilePostParameters,
   ICourierProfilePostResponse,
   ICourierProfilePutParameters,
-  ICourierProfilePutResponse,
+  ICourierProfilePutResponse
 } from "./types";
 
 export const replaceProfile = (options: ICourierClientConfiguration) => {
@@ -20,7 +20,7 @@ export const replaceProfile = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.put<ICourierProfilePutResponse>(
       `/profiles/${params.recipientId}`,
       {
-        profile: params.profile,
+        profile: params.profile
       }
     );
     return res.data;
@@ -33,7 +33,7 @@ export const mergeProfile = (options: ICourierClientConfiguration) => {
     config?: ICourierProfilePostConfig
   ): Promise<ICourierProfilePostResponse> => {
     const axiosConfig: AxiosRequestConfig = {
-      headers: {},
+      headers: {}
     };
 
     if (config && config.idempotencyKey) {
@@ -42,7 +42,7 @@ export const mergeProfile = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.post<ICourierProfilePostResponse>(
       `/profiles/${params.recipientId}`,
       {
-        profile: params.profile,
+        profile: params.profile
       },
       axiosConfig
     );
@@ -87,7 +87,7 @@ export const addRecipientToLists = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.post<ICourierProfilePostResponse>(
       `/profiles/${params.recipientId}/lists`,
       {
-        lists: params.lists,
+        lists: params.lists
       }
     );
     return res.data;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,12 +4,12 @@ import { ICourierClientAutomations } from "./automations/types";
 import {
   ICourierClientLists,
   ICourierList,
-  ICourierRecipientSubscriptionsResponse,
+  ICourierRecipientSubscriptionsResponse
 } from "./lists/types";
 import { ICourierClientNotifications } from "./notifications/types";
 import {
   ICourierClientPreferences,
-  IRecipientPreferences,
+  IRecipientPreferences
 } from "./preferences/types";
 
 export type HttpMethodClient = <T>(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,11 +1,15 @@
 import { AxiosRequestConfig } from "axios";
 
 import { ICourierClientAutomations } from "./automations/types";
-import { ICourierClientLists, ICourierList } from "./lists/types";
+import {
+  ICourierClientLists,
+  ICourierList,
+  ICourierRecipientSubscriptionsResponse,
+} from "./lists/types";
 import { ICourierClientNotifications } from "./notifications/types";
 import {
   ICourierClientPreferences,
-  IRecipientPreferences
+  IRecipientPreferences,
 } from "./preferences/types";
 
 export type HttpMethodClient = <T>(
@@ -378,7 +382,7 @@ export interface ICourierClient {
   deleteProfile: (params: ICourierProfileDeleteParameters) => Promise<void>;
   getRecipientSubscriptions: (
     params: ICourierProfileGetParameters
-  ) => Promise<ICourierList[]>;
+  ) => Promise<ICourierRecipientSubscriptionsResponse>;
   lists: ICourierClientLists;
   mergeProfile: (
     params: ICourierProfilePostParameters,


### PR DESCRIPTION
## Description of the change

response from `profiles/suhas/lists` which is `getRecipientSubscriptions` calls responds with following 

```ts
{
  "paging": {
    "cursor": null,
    "more": false
  },
  "results": []
}
```

So `ICourierList[]` is not right. This PR changes the type definition and adds proper type to the response from `getRecipientSubscriptions`

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
