### PR TITLE
C-4498: Expose more properties of a message in getMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [v3.1.0] - 2021-11-16
+
+- Expose additional type definitions for `getMessage`
+
 ## [v3.0.0] - 2021-11-02
 
 - fixes type definition for `getRecipientSubscriptions`
@@ -177,7 +181,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.0.1 - 2019-07-12
 
-[unreleased]: https://github.com/trycourier/courier-node/compare/v3.0.0...HEAD
+[unreleased]: https://github.com/trycourier/courier-node/compare/v3.1.0...HEAD
+[v3.1.0]: https://github.com/trycourier/courier-node/compare/v3.0.0...v3.1.0
 [v3.0.0]: https://github.com/trycourier/courier-node/compare/v2.8.0...v3.0.0
 [v2.8.0]: https://github.com/trycourier/courier-node/compare/v2.7.0...v2.8.0
 [v2.7.0]: https://github.com/trycourier/courier-node/compare/v2.6.0...v2.7.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -35,7 +35,7 @@ const mockGetProfileResponse: ICourierProfileGetResponse = {
 const mockGetMessageResponse: ICourierMessageGetResponse = {
   id: "mockMessageId",
   recipient: "mockRecipient",
-  status: "mockStatus"
+  status: "SENT"
 };
 
 const mockGetMessageHistoryResponse: ICourierMessageGetHistoryResponse = {
@@ -156,7 +156,7 @@ const mockGetMessagesResponse: ICourierMessagesGetResponse = {
       enqueued: 1632840573355,
       sent: 1632840580620,
       recipient: "mockRecipient",
-      status: "mockStatus",
+      status: "SENT",
       event: "mockEvent",
       notification: "mockNotification"
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,25 +141,38 @@ export interface ICourierMessagesGetResponse {
 }
 
 export interface ICourierMessageGetResponse {
+  clicked?: number;
+  delivered?: number;
   enqueued?: number;
+  error?: string;
   event?: string;
   id: string;
+  idempotencyKey?: string;
+  listId?: string;
+  listMessageId?: string;
   notification?: string;
+  opened?: number;
   providers?: Array<{
     channel: {
-      name: string;
+      key?: string;
+      name?: string;
       template: string;
     };
+    clicked?: number;
+    delivered?: number;
+    error?: string;
     provider: string;
-    reference: {
-      "x-message-id": string;
-    };
+    reference?: { [key: string]: string | number };
     sent: number;
-    status: string;
+    status: MessageStatus;
   }>;
+  reason?: MessageStatusReason;
+  reasonCode?: MessageStatusReasonCode;
+  reasonDetails?: string;
   recipient: string;
+  runId?: string;
   sent?: number;
-  status: string;
+  status: MessageStatus;
 }
 
 export type MessageStatus =


### PR DESCRIPTION
## Description of the change

GET /messages/{message_id} supports a bunch of properties on a message that weren't exposed via the SDK

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

-

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
