### PR TITLE
C-4538: Add support for idempotency key expiration in send and send list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [v3.2.0] - 2021-11-18
+
+- adds idempotency expiration support for send and send list endpoints
+
 ## [v3.1.0] - 2021-11-16
 
 - Expose additional type definitions for `getMessage`
@@ -181,7 +185,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.0.1 - 2019-07-12
 
-[unreleased]: https://github.com/trycourier/courier-node/compare/v3.1.0...HEAD
+[unreleased]: https://github.com/trycourier/courier-node/compare/v3.2.0...HEAD
+[v3.2.0]: https://github.com/trycourier/courier-node/compare/v3.1.0...v3.2.0
 [v3.1.0]: https://github.com/trycourier/courier-node/compare/v3.0.0...v3.1.0
 [v3.0.0]: https://github.com/trycourier/courier-node/compare/v2.8.0...v3.0.0
 [v2.8.0]: https://github.com/trycourier/courier-node/compare/v2.7.0...v2.8.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -251,7 +251,9 @@ describe("CourierClient", () => {
         recipientId: "RECIPIENT_ID"
       },
       {
-        idempotencyKey: "IDEMPOTENCY_KEY_UUID"
+        idempotencyKey: "IDEMPOTENCY_KEY_UUID",
+        // e.g. expiration date in epoch time, 30 mins from now
+        idempotencyExpiry: Date.now() + 30 * 60 * 1000
       }
     );
   });

--- a/src/client.ts
+++ b/src/client.ts
@@ -47,6 +47,11 @@ const send = (options: ICourierClientConfiguration) => {
       axiosConfig.headers["Idempotency-Key"] = config.idempotencyKey;
     }
 
+    if (config && config.idempotencyExpiry) {
+      axiosConfig.headers["x-idempotency-expiration"] =
+        config.idempotencyExpiry;
+    }
+
     const res = await options.httpClient.post<ICourierSendResponse>(
       "/send",
       {

--- a/src/lists/index.ts
+++ b/src/lists/index.ts
@@ -142,6 +142,11 @@ const send = (options: ICourierClientConfiguration) => {
       axiosConfig.headers["Idempotency-Key"] = config.idempotencyKey;
     }
 
+    if (config && config.idempotencyExpiry) {
+      axiosConfig.headers["x-idempotency-expiration"] =
+        config.idempotencyExpiry;
+    }
+
     const res = await options.httpClient.post<ICourierSendResponse>(
       `/send/list`,
       params,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,6 +49,7 @@ export interface ICourierSendParameters {
 
 export interface ICourierSendConfig {
   idempotencyKey?: string;
+  idempotencyExpiry?: number;
 }
 
 export interface ICourierSendResponse {


### PR DESCRIPTION
## Description of the change

Add support for idempotency key expiration in send and send list

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

None

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
