### PR TITLE
Fix getMessages query params logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [v3.2.1] - 2022-01-13
+
+- Fixes `getMessages` query params
+
 ## [v3.2.0] - 2021-11-18
 
 - adds idempotency expiration support for send and send list endpoints
@@ -185,7 +189,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.0.1 - 2019-07-12
 
-[unreleased]: https://github.com/trycourier/courier-node/compare/v3.2.0...HEAD
+[unreleased]: https://github.com/trycourier/courier-node/compare/v3.2.1...HEAD
+[v3.2.1]: https://github.com/trycourier/courier-node/compare/v3.2.0...v3.2.1
 [v3.2.0]: https://github.com/trycourier/courier-node/compare/v3.1.0...v3.2.0
 [v3.1.0]: https://github.com/trycourier/courier-node/compare/v3.0.0...v3.1.0
 [v3.0.0]: https://github.com/trycourier/courier-node/compare/v2.8.0...v3.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/client.ts
+++ b/src/client.ts
@@ -107,13 +107,15 @@ const getMessages = (options: ICourierClientConfiguration) => {
     const res = await options.httpClient.get<ICourierMessagesGetResponse>(
       "/messages",
       {
-        cursor: params?.cursor,
-        event: params?.eventId,
-        list: params?.listId,
-        messageId: params?.messageId,
-        notification: params?.notificationId,
-        recipient: params?.recipientId,
-        status: params?.status
+        params: {
+          cursor: params?.cursor,
+          event: params?.eventId,
+          list: params?.listId,
+          messageId: params?.messageId,
+          notification: params?.notificationId,
+          recipient: params?.recipientId,
+          status: params?.status
+        }
       }
     );
     return res.data;


### PR DESCRIPTION
## Description of the change

Fix query params not being passed correctly in getMessages

Current (buggy):

![Screen Shot 2022-01-13 at 7 46 57 PM](https://user-images.githubusercontent.com/6154318/149448295-6c5423c8-cb32-4d18-b2e0-6f0c3c2b1665.png)

With the fix:
![Screen Shot 2022-01-13 at 7 45 08 PM](https://user-images.githubusercontent.com/6154318/149448140-acc0ebbc-bdd0-4891-ad79-df7c3014837a.png)
![Screen Shot 2022-01-13 at 7 45 00 PM](https://user-images.githubusercontent.com/6154318/149448143-0f1f3680-fdeb-4fe6-a288-cdda1aa08b4d.png)



## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
