### PR TITLE
Add type for unroutable status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [v3.5.0] - 2022-02-10
+
+- adds type for unroutable status
+
 ## [v3.4.0] - 2022-01-25
 
 - adds support for the send message object in the request body of a `/send` call
@@ -197,7 +201,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v1.0.1 - 2019-07-12
 
-[unreleased]: https://github.com/trycourier/courier-node/compare/v3.4.0...HEAD
+[unreleased]: https://github.com/trycourier/courier-node/compare/v3.5.0...HEAD
+[v3.5.0]: https://github.com/trycourier/courier-node/compare/v3.4.0...v3.5.0
 [v3.4.0]: https://github.com/trycourier/courier-node/compare/v3.3.0...v3.4.0
 [v3.3.0]: https://github.com/trycourier/courier-node/compare/v3.2.1...v3.3.0
 [v3.2.1]: https://github.com/trycourier/courier-node/compare/v3.2.0...v3.2.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,12 +5,12 @@ import { ICourierClientBulk } from "./bulk/types";
 import {
   ICourierClientLists,
   ICourierList,
-  ICourierRecipientSubscriptionsResponse
+  ICourierRecipientSubscriptionsResponse,
 } from "./lists/types";
 import { ICourierClientNotifications } from "./notifications/types";
 import {
   ICourierClientPreferences,
-  IRecipientPreferences
+  IRecipientPreferences,
 } from "./preferences/types";
 import { Message } from "./send/types";
 
@@ -195,7 +195,8 @@ export type MessageStatus =
   | "SENT"
   | "SIMULATED"
   | "UNDELIVERABLE"
-  | "UNMAPPED";
+  | "UNMAPPED"
+  | "UNROUTABLE";
 
 export type MessageHistoryType =
   | MessageStatus
@@ -250,6 +251,11 @@ export interface IRenderedMessageHistory
   };
 }
 
+export interface IUnroutableMessageHistory
+  extends IMessageHistory<"UNROUTABLE"> {
+  reason: MessageStatusReason;
+}
+
 export interface IUndeliverableMessageHistory
   extends IMessageHistory<"UNDELIVERABLE">,
     Partial<Omit<IRoutedMessageHistory<"UNDELIVERABLE">, "ts" | "type">> {
@@ -294,6 +300,7 @@ export interface ICourierMessageGetHistoryResponse {
     | IDeliveredMessageHistory
     | IProviderErrorMessageHistory
     | IUndeliverableMessageHistory
+    | IUnroutableMessageHistory
   >;
 }
 


### PR DESCRIPTION
## Description of the change

Courier backend is introducing new state `unroutable`. Adding types to keep the SDK in sync.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
