### PR TITLE
[C-5575] Support message.brand_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-## [3.10.0] - 2022-03-20
+## [3.10.1] - 2022-03-20
 - adds support for messages timeout (`message.timeout`)
+
+## [3.10.0] - 2020-03-24
+- adds support for messages brand_id (`message.brand_id`)
 
 ## [3.9.0] - 2022-03-17
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/send/types.ts
+++ b/src/send/types.ts
@@ -296,7 +296,7 @@ export interface Timeout {
 export type Content = ElementalContentSugar | ElementalContent;
 
 export interface BaseMessage {
-  // brands?: MessageBrands; TODO: https://linear.app/trycourier/issue/C-4476/add-brand-level-overrides-to-v2-request
+  brand_id?: string;
   channels?: MessageChannels;
   data?: MessageData;
   metadata?: MessageMetadata;


### PR DESCRIPTION
## Description of the change

Adds support for message.brand_id.

Tested with the following call:
```
  const { requestId } = await courier.send({
    message: {
      to: {
        email: "drew@example.com",
      },
      content: {
        title: "EMAIL TITLE HERE",
        body: "Hello there! (But in a pretty font)",
      },
      routing: {
        method: "single",
        channels: ["email"],
      },
      brand_id: "red_brand",
    },
  });
```

Result:

<img width="587" alt="Screen Shot 2022-03-24 at 10 13 56 AM" src="https://user-images.githubusercontent.com/7987513/159972794-8f50538d-d4f9-4d21-8f57-3e247822fca2.png">


## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

