### PR TITLE
Added example for granular timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+- adds support for granular timeouts for channel and providers
 - adds support for change and provider utm metadata (`channels.metadata.utm` and `providers.metadata.utm`) that augments action blocks links
 
 ## [3.12.0] - 2022-03-31

--- a/README.md
+++ b/README.md
@@ -277,20 +277,31 @@ async function run() {
           campaign: "c",
         },
       },
+      timeout: {
+        message: 300000,
+        channel: {
+          email: 1000 // 1 second
+        }
+      }
     },
   });
 
 /**
  * If the template or content contains any action blocks, the hyperlinks will be augmented with utm compliant query parameters.
- * 
+ *
  * The resulting link of an action block sent through sendgrid would be:
  * www.example.com?utm_source=a&utm_medium=f&utm_campaign=g
- * 
+ *
  * While the resulting link of an action block sent through sns would be:
  * www.example.com?utm_source=a&utm_medium=h&utm_campaign=g
- * 
+ *
  * Notice that provider metadata supersedes channel metadata and channel metadata supersedes message metadata
- * 
+ *
+ **/
+
+/**
+ * If the message includes a timeout property we will start timing out messages after the first attempt.
+ * We are able to timeout complete channels or specific providers.
  **/
 
   // Example: get a message status

--- a/src/send/types.ts
+++ b/src/send/types.ts
@@ -294,8 +294,8 @@ export interface ElementalContentSugar {
 }
 
 export interface Timeout {
-  provider?: number;
-  channel?: number;
+  provider?: { [provider: string]: number };
+  channel?: { [channel: string]: number };
   message?: number;
   escalation?: number;
   criteria?: "no-escalation" | "delivered" | "viewed" | "engaged";


### PR DESCRIPTION
## Description of the change

- This PR modifies the type of message to include provider and channel timeouts.

```json
{
	"message": {
		"to": {},
		"content": {}
		"channels": {},
		"providers": {},
		"timeout": {
			"message": 300000,
			"provider": {
				"mailjet": 300000
			},
			"channel": {
				"email": 0
			}
		}
	}
}
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://linear.app/trycourier/issue/C-6093/node-sdk

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
