### PR TITLE
Brands and profiles POST add support for idempotency expiration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [3.16.0]
+
+- adds support for idempotency expiry to be passed in profiles and brands POST
+
 ## [3.15.0]
 
 - adds support for audit events

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/brands.ts
+++ b/src/brands.ts
@@ -41,6 +41,10 @@ export const createBrand = (options: ICourierClientConfiguration) => {
     if (config && config.idempotencyKey) {
       axiosConfig.headers["Idempotency-Key"] = config.idempotencyKey;
     }
+    if (config && config.idempotencyExpiry) {
+      axiosConfig.headers["x-idempotency-expiration"] =
+        config.idempotencyExpiry;
+    }
     const res = await options.httpClient.post<ICourierBrand>(
       `/brands`,
       params,

--- a/src/profile.ts
+++ b/src/profile.ts
@@ -39,6 +39,10 @@ export const mergeProfile = (options: ICourierClientConfiguration) => {
     if (config && config.idempotencyKey) {
       axiosConfig.headers["Idempotency-Key"] = config.idempotencyKey;
     }
+    if (config && config.idempotencyExpiry) {
+      axiosConfig.headers["x-idempotency-expiration"] =
+        config.idempotencyExpiry;
+    }
     const res = await options.httpClient.post<ICourierProfilePostResponse>(
       `/profiles/${params.recipientId}`,
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,7 @@ export interface ICourierProfileListsPostParameters {
 
 export interface ICourierProfilePostConfig {
   idempotencyKey?: string;
+  idempotencyExpiry?: number;
 }
 
 export interface ICourierProfilePostResponse {
@@ -376,6 +377,7 @@ export interface ICourierBrandParameters {
 
 export interface ICourierBrandPostConfig {
   idempotencyKey?: string;
+  idempotencyExpiry?: number;
 }
 
 export interface ICourierBrandPutParameters extends ICourierBrandParameters {


### PR DESCRIPTION
## Description of the change

Brands and profiles POST add support for idempotency expiration

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
