### PR TITLE
[C-7364] - Node 18.x support; BaseURL fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [v4.0.2] - 2022-10-19
+
+- Fix `unexpected error` in Node 18.x
+- Fix baseURLs getting chopped off   
+
 ## [v4.0.1] - 2022-10-13
 
 - resolves `FetchError: invalid json response body` for API's returning no body
@@ -259,6 +264,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## v1.0.1 - 2019-07-12
 
 [unreleased]: https://github.com/trycourier/courier-node/compare/v4.0.1...HEAD
+[v4.0.2]: https://github.com/trycourier/courier-node/compare/v4.0.1...v4.0.2
 [v4.0.1]: https://github.com/trycourier/courier-node/compare/v4.0.0...v4.0.1
 [v4.0.0]: https://github.com/trycourier/courier-node/compare/v3.16.0...v4.0.0
 [v3.11.0]: https://github.com/trycourier/courier-node/compare/v3.10.0...v3.11.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/http-client.test.ts
+++ b/src/__tests__/http-client.test.ts
@@ -1,0 +1,39 @@
+import fetchMock from "jest-fetch-mock";
+import { initHttpClient } from "../http-client";
+
+
+describe('HttpClient', () => {
+  beforeEach(() => {
+    fetchMock.resetMocks();
+    fetchMock.doMockOnce();
+  });
+
+  test('should have auth token', async () => {
+    const token = 'test-auth-token';
+    const client = initHttpClient({
+      baseUrl: '', version: '1', authorizationToken: token
+    });
+    await client.get('https://api.courier.com/lists/list-1');
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    const expectedAuth = { headers: { Authorization: `Bearer ${token}` } }
+    expect(fetchMock.mock.calls[0][1]).toMatchObject(expectedAuth);
+  });
+
+  test('should URI encode values', async () => {
+    const client = initHttpClient({
+      baseUrl: '', version: '1', authorizationToken: 'auth-token'
+    })
+    await client.put('https://api.courier.com/lists/list-1/subscriptions/subscriber|some-value+other-value');
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual('https://api.courier.com/lists/list-1/subscriptions/subscriber%7Csome-value+other-value');
+  })
+
+  test('should prepend baseURL', async () => {
+    const client = initHttpClient({
+      baseUrl: 'https://execute-api.us-east-1.amazonaws.com/dev', version: '1', authorizationToken: 'auth-token'
+    });
+    await client.get('/lists/list1|test.list');
+    expect(fetchMock.mock.calls.length).toEqual(1);
+    expect(fetchMock.mock.calls[0][0]).toEqual('https://execute-api.us-east-1.amazonaws.com/dev/lists/list1%7Ctest.list');
+  });
+});

--- a/src/__tests__/http-client.test.ts
+++ b/src/__tests__/http-client.test.ts
@@ -23,9 +23,9 @@ describe('HttpClient', () => {
     const client = initHttpClient({
       baseUrl: '', version: '1', authorizationToken: 'auth-token'
     })
-    await client.put('https://api.courier.com/lists/list-1/subscriptions/subscriber|some-value+other-value');
+    await client.put('https://api.courier.com/lists/list-1/subscriptions/subscriber|some-value+other-value?query=param');
     expect(fetchMock.mock.calls.length).toEqual(1);
-    expect(fetchMock.mock.calls[0][0]).toEqual('https://api.courier.com/lists/list-1/subscriptions/subscriber%7Csome-value+other-value');
+    expect(fetchMock.mock.calls[0][0]).toEqual('https://api.courier.com/lists/list-1/subscriptions/subscriber%7Csome-value+other-value?query=param');
   })
 
   test('should prepend baseURL', async () => {

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -29,7 +29,7 @@ export const initHttpClient = ({
     return async <T>(...[url, body, config]: Parameters<HttpMethodClient>) => {
       const searchParams = String(new URLSearchParams(config?.params));
       const searchQueryString = searchParams && `?${searchParams}`;
-      const fullUrl = encodeURI(String(new URL(`${url}${searchQueryString}`, baseUrl)));
+      const fullUrl = encodeURI(`${baseUrl ?? ''}${url}${searchQueryString}`);
       const contentTypeHeader =
         body == null ? null : { "Content-Type": "application/json" };
       const idempotencyKeyHeader = config?.idempotencyKey

--- a/src/http-client.ts
+++ b/src/http-client.ts
@@ -29,7 +29,7 @@ export const initHttpClient = ({
     return async <T>(...[url, body, config]: Parameters<HttpMethodClient>) => {
       const searchParams = String(new URLSearchParams(config?.params));
       const searchQueryString = searchParams && `?${searchParams}`;
-      const fullUrl = String(new URL(`${url}${searchQueryString}`, baseUrl));
+      const fullUrl = encodeURI(String(new URL(`${url}${searchQueryString}`, baseUrl)));
       const contentTypeHeader =
         body == null ? null : { "Content-Type": "application/json" };
       const idempotencyKeyHeader = config?.idempotencyKey


### PR DESCRIPTION
## Description of the change

> Fix `unexpected error` in Node 18.x. Node 18.x uses an [experimental fetch](https://nodejs.org/de/blog/announcements/v18-release-announce/#fetch-experimental) by default and this is not properly encoding URIs correctly
> Fix baseURLs getting chopped off. Ex. `https://some-url.com/dev/` -> `https://some-url.com`

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
