### PR TITLE
[C-10450] adds support for user preferences endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,22 +434,6 @@ async function run() {
   );
   console.log(items);
 
-  // Example: Notification Preferences
-  await courier.preferences.put(recipientId, {
-    notifications: {
-      "<NOTIFICATION_ID>": { status: "<OPT_IN_STATUS>" },
-    },
-  });
-  // Where OPT_IN_STATUS = "OPTED_IN" | "OPTED_OUT"
-
-  // Example: Get a list of existing notifications and categories
-  const prefs = await courier.preferences.list();
-  console.log(prefs);
-
-  // Example: Get the preferences stored under a specified recipient ID.
-  const profilePrefs = await courier.preferences.get(recipientId);
-  console.log(profilePrefs);
-
   // Example: Automation Ad-Hoc Invoke
   const { runId } = await courier.automations.invokeAdHocAutomation({
     automation: {
@@ -840,6 +824,36 @@ await courier.users.put("<USER_ID>", {
 await courier.users.putAccounts("<USER_ID>", {
   accounts: [{ account_id: "ACCOUNT_ID", profile: { foo: "bar" } }],
 });
+```
+
+#### Updating user preferences
+
+Courier currently does not allow creating new topics via the API. You must create topics via the Courier UI. Once a topic is created, you can update a user's preferences for that topic via the API.
+
+```ts
+await courier.users.putUserPreferenceByTopic(mockUserId, "<VALID_TOPIC_ID>", {
+  default_status: "OPTED_IN",
+  status: "OPTED_OUT",
+});
+```
+
+#### Getting user preferences
+
+- Get all topic level preferences for a user
+
+```ts
+const { items: userPreferences } = await courier.users.getUserPreferences(
+  "<USER_ID>"
+);
+```
+
+- Get a specific topic level preference for a user
+
+```ts
+const userPreference = await courier.users.getUserPreferenceByTopic(
+  "<USER_ID>",
+  "<VALID_TOPIC_ID>"
+);
 ```
 
 ## License

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -9,38 +9,115 @@ describe("CourierUsers", () => {
       {
         method: "PUT",
         path: `/users/${mockUserId}`,
-        response: { status: 204 }
+        response: { status: 204 },
       },
       {
         method: "PUT",
         path: `/users/${mockUserId}/accounts`,
-        response: { status: 204 }
-      }
+        response: { status: 204 },
+      },
+      {
+        method: "PUT",
+        path: `/users/${mockUserId}/preferences/topic-1`,
+        response: { status: 200 },
+      },
+      {
+        method: "GET",
+        path: `/users/${mockUserId}/preferences/topic-1`,
+        response: {
+          body: {
+            topic: {
+              default_status: "OPT_IN",
+              has_custom_routing: true,
+              custom_routing: ["email"],
+              status: "OPTED_OUT",
+              topic_id: "FW0YU64P4TMYKMMHH67D6FENX8VS",
+              topic_name: "Invitations",
+            },
+          },
+        },
+      },
+      {
+        method: "GET",
+        path: `/users/${mockUserId}/preferences`,
+        response: {
+          body: {
+            paging: {
+              cursor:
+                "MTU4OTQ5NTI1ODY4NywxLTVlYmRjNWRhLTEwODZlYWFjMWRmMjEwMTNjM2I0ZjVhMA==",
+              more: true,
+            },
+            items: [
+              {
+                default_status: "OPT_IN",
+                has_custom_routing: true,
+                custom_routing: ["email"],
+                status: "OPTED_OUT",
+                topic_id: "FW0YU64P4TMYKMMHH67D6FENX8VS",
+                topic_name: "Invitations",
+              },
+            ],
+          },
+        },
+      },
     ]);
   });
 
   test(".put", async () => {
     const { users } = CourierClient({
-      authorizationToken: "AUTH_TOKEN"
+      authorizationToken: "AUTH_TOKEN",
     });
 
     await expect(
       users.put(mockUserId, {
         accounts: [{ account_id: "account-1", profile: { foo: "bar" } }],
-        profile: { name: "John Doe" }
+        profile: { name: "John Doe" },
       })
     ).resolves.not.toThrow();
   });
 
   test(".putAccounts", async () => {
     const { users } = CourierClient({
-      authorizationToken: "AUTH_TOKEN"
+      authorizationToken: "AUTH_TOKEN",
     });
 
     await expect(
       users.putAccounts(mockUserId, [
-        { account_id: "account-1", profile: { foo: "bar" } }
+        { account_id: "account-1", profile: { foo: "bar" } },
       ])
+    ).resolves.not.toThrow();
+  });
+
+  test(".putUserPreferences", async () => {
+    const { users } = CourierClient({
+      authorizationToken: "AUTH_TOKEN",
+    });
+
+    await expect(
+      users.putUserPreferenceByTopic(mockUserId, "topic-1", {
+        default_status: "OPTED_IN",
+        status: "OPTED_OUT",
+      })
+    ).resolves.not.toThrow();
+  });
+
+  test(".getPrefsByTopic", async () => {
+    const { users } = CourierClient({
+      authorizationToken: "AUTH_TOKEN",
+    });
+
+    await expect(
+      users.getUserPreferenceByTopic(mockUserId, "topic-1")
+    ).resolves.not.toThrow();
+  });
+
+  test(".getUserPreferences", async () => {
+    const { users } = CourierClient({
+      authorizationToken: "AUTH_TOKEN",
+    });
+
+    await expect(
+      users.getUserPreferenceByTopics(mockUserId)
     ).resolves.not.toThrow();
   });
 });

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -1,11 +1,17 @@
 import { ICourierClientConfiguration } from "../types";
-import { IUser, IUserAccount } from "./types";
+import {
+  IGetTopicPreferencesResponse,
+  ITopicPreference,
+  IUser,
+  IUserAccount,
+} from "./types";
 
 const put = (options: ICourierClientConfiguration) => {
   return async (id: string, user: IUser): Promise<void> => {
     await options.httpClient.put<IUser>(`/users/${id}`, user);
   };
 };
+
 const putAccounts = (options: ICourierClientConfiguration) => {
   return async (id: string, accounts: IUserAccount[]): Promise<void> => {
     await options.httpClient.put<{
@@ -14,7 +20,43 @@ const putAccounts = (options: ICourierClientConfiguration) => {
   };
 };
 
+const putUserPreferenceByTopic = (options: ICourierClientConfiguration) => {
+  return async (
+    userId: string,
+    topicId: string,
+    topic: Omit<ITopicPreference, "topic_id" | "topic_name">
+  ): Promise<void> => {
+    await options.httpClient.put<object>(
+      `/users/${userId}/preferences/${topicId}`,
+      {
+        topic,
+      }
+    );
+  };
+};
+
+const getUserPreferenceByTopic = (options: ICourierClientConfiguration) => {
+  return async (userId: string, topicId: string): Promise<ITopicPreference> => {
+    const res = await options.httpClient.get<IGetTopicPreferencesResponse>(
+      `/users/${userId}/preferences/${topicId}`
+    );
+    return res.data?.topic;
+  };
+};
+
+const getUserPreferenceByTopics = (options: ICourierClientConfiguration) => {
+  return async (userId: string): Promise<object> => {
+    const res = await options.httpClient.get<{}>(
+      `/users/${userId}/preferences`
+    );
+    return res.data;
+  };
+};
+
 export const users = (options: ICourierClientConfiguration) => ({
+  getUserPreferenceByTopic: getUserPreferenceByTopic(options),
+  getUserPreferenceByTopics: getUserPreferenceByTopics(options),
   put: put(options),
-  putAccounts: putAccounts(options)
+  putAccounts: putAccounts(options),
+  putUserPreferenceByTopic: putUserPreferenceByTopic(options),
 });

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -8,7 +8,51 @@ export interface IUser {
   profile: Record<string, any>;
 }
 
+export type ChannelClassification =
+  | "direct_message"
+  | "email"
+  | "push"
+  | "sms"
+  | "webhook"
+  | "inbox";
+
+export interface ITopicPreference {
+  /**
+   * Should contain unique items.
+   */
+  custom_routing?: ChannelClassification[];
+  default_status: "OPTED_IN" | "OPTED_OUT";
+  has_custom_routing?: boolean;
+  status: "OPTED_IN" | "OPTED_OUT";
+  topic_id: string;
+  topic_name: string;
+}
+
+interface IPagingInfo {
+  cursor: string;
+  more: boolean;
+}
+
+export interface IGetTopicPreferencesResponse {
+  topic: ITopicPreference;
+}
+
+export interface IGetTopicsResponse {
+  paging: IPagingInfo;
+  items: ITopicPreference[];
+}
+
 export interface ICourierClientUsers {
+  getUserPreferenceByTopic: (
+    userId: string,
+    topicId: string
+  ) => Promise<IGetTopicPreferencesResponse>;
+  getUserPreferenceByTopics: (userId: string) => Promise<IGetTopicsResponse>;
   put: (id: string, user: IUser) => Promise<void>;
   putAccounts: (id: string, accounts: IUserAccount[]) => Promise<void>;
+  putUserPreferenceByTopic: (
+    userId: string,
+    topicId: string,
+    topic: Omit<ITopicPreference, "topic_id" | "topic_name">
+  ) => Promise<void>;
 }


### PR DESCRIPTION
## Description of the change

Adds support for https://www.courier.com/docs/reference/user-preferences/ APIs in SDK

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

