### PR TITLE
Add support for MessageDelay and duration in send message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/send/types.ts
+++ b/src/send/types.ts
@@ -197,6 +197,10 @@ export interface MessageContext {
 
 export interface MessageData extends Record<string, any> {}
 
+export interface MessageDelay {
+  duration?: number;
+}
+
 export type RuleType = "snooze" | "channel_preferences" | "status";
 
 export interface IRule<T extends RuleType> {
@@ -330,6 +334,7 @@ export interface BaseMessage {
   channels?: MessageChannels;
   context?: MessageContext;
   data?: MessageData;
+  delay?: MessageDelay;
   metadata?: MessageMetadata;
   providers?: MessageProviders;
   routing?: Routing;


### PR DESCRIPTION
## Description of the change

Defines the time to wait before delivering the message
See [details](https://www.courier.com/docs/reference/send/message/)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
