### PR TITLE
Add support for cursor query param in Audience API

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,6 +748,7 @@ const { audienceId } = await courier.audiences.put({
 // To retrieve list of members in a given audience, you can use the following:
 const { items: audienceMembers } = await courier.audiences.listMembers(
   audienceId
+  cursor: "<CURSOR>", // optional
 );
 
 // To send a notification to all users that match the given filter criteria, you can use the following:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trycourier/courier",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "description": "A node.js module for communicating with the Courier REST API.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/audiences/index.ts
+++ b/src/audiences/index.ts
@@ -17,21 +17,30 @@ const getAudience = (options: ICourierClientConfiguration) => {
 };
 
 const listAudiences = (options: ICourierClientConfiguration) => {
-  return async (): Promise<AudienceTypes.IAudienceListResponse> => {
+  return async (params?: {
+    cursor: string;
+  }): Promise<AudienceTypes.IAudienceListResponse> => {
     const response = await options.httpClient.get<
-      AudienceTypes.IAudienceListResponse
-    >("/audiences");
+      AudienceTypes.IAudienceListResponse>(
+        "/audiences",
+        params
+    );
     return response.data;
   };
 };
 
 const listMembers = (options: ICourierClientConfiguration) => {
   return async (
-    audienceId: string
+    audienceId: string,
+    params?: {
+      cursor: string;
+    }
   ): Promise<AudienceTypes.IAudienceMemberListResponse> => {
     const response = await options.httpClient.get<
       AudienceTypes.IAudienceMemberListResponse
-    >(`/audiences/${audienceId}/members`);
+    >(
+      `/audiences/${audienceId}/members`,
+      params);
     return response.data;
   };
 };

--- a/src/audiences/types.ts
+++ b/src/audiences/types.ts
@@ -76,8 +76,12 @@ export interface IAudiencePutResponse {
 export interface ICourierClientAudiences {
   delete: (id: string) => Promise<void>;
   get: (id: string) => Promise<IAudience>;
-  listAudiences: () => Promise<IAudienceListResponse>;
-  listMembers: (id: string) => Promise<IAudienceMemberListResponse>;
+  listAudiences: (params?: {
+    cursor: string;
+  }) => Promise<IAudienceListResponse>;
+  listMembers: (id: string, params?: {
+    cursor: string;
+  }) => Promise<IAudienceMemberListResponse>;
   put: (
     audience: Omit<IAudience, "created_at" | "updated_at">
   ) => Promise<IAudience>;


### PR DESCRIPTION
- List all audiences [1]
- List audience members [2] Ref:
[1] https://www.courier.com/docs/reference/audiences/list-audiences/ [2]
https://www.courier.com/docs/reference/audiences/list-audience-members/

## Description of the change

> Description here

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
