### PR TITLE
feat(api): restore the /bulk endpoints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     timeout-minutes: 10
     name: lint
-    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -37,7 +37,7 @@ jobs:
   build:
     timeout-minutes: 5
     name: build
-    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.fork) && (github.event_name != 'push' || github.event.head_commit.message != 'codegen metadata')
     permissions:
       contents: read
@@ -55,40 +55,3 @@ jobs:
 
       - name: Check build
         run: ./scripts/build
-
-      - name: Get GitHub OIDC Token
-        if: |-
-          github.repository == 'stainless-sdks/courier-typescript' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
-        id: github-oidc
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        with:
-          script: core.setOutput('github_token', await core.getIDToken());
-
-      - name: Upload tarball
-        if: |-
-          github.repository == 'stainless-sdks/courier-typescript' &&
-          !startsWith(github.ref, 'refs/heads/stl/')
-        env:
-          URL: https://pkg.stainless.com/s
-          AUTH: ${{ steps.github-oidc.outputs.github_token }}
-          SHA: ${{ github.sha }}
-        run: ./scripts/utils/upload-artifact.sh
-  test:
-    timeout-minutes: 10
-    name: test
-    runs-on: ${{ startsWith(github.repository, 'stainless-sdks/') && 'depot-ubuntu-24.04' || 'ubuntu-latest' }}
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.fork
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
-      - name: Set up Node
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: '24'
-
-      - name: Bootstrap
-        run: ./scripts/bootstrap
-
-      - name: Run tests
-        run: ./scripts/test

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,12 +1,8 @@
-# This workflow is triggered when a GitHub release is created.
-# It can also be run manually to re-publish to NPM in case it failed for some reason.
-# You can run this workflow by navigating to https://www.github.com/trycourier/courier-node/actions/workflows/publish-npm.yml
+# This workflow publishes the package to NPM.
+# You can run this workflow manually by navigating to https://www.github.com/trycourier/courier-node/actions/workflows/publish-npm.yml
 name: Publish NPM
 on:
   workflow_dispatch:
-
-  release:
-    types: [published]
 
 jobs:
   publish:

--- a/.github/workflows/release-doctor.yml
+++ b/.github/workflows/release-doctor.yml
@@ -17,3 +17,5 @@ jobs:
       - name: Check release environment
         run: |
           bash ./bin/check-release-environment
+        env:
+          RELEASE_PLEASE_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,1 @@
-configured_endpoints: 145
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/courier/courier-82881993f19c5fac9ac662f1a516e5b54bd7c6655d07f29a3779dfb0286cafd3.yml
-openapi_spec_hash: 92f4c510a5a15d091036d70caa8ee573
-config_hash: 768b0f5ada2bf01cf2659d5dbbad1fa0
+configured_endpoints: 150

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<!-- AUTO-GENERATED-OVERVIEW:START — Do not edit this section. It is synced from mintlify-docs. -->
-
 # Courier Node.js SDK
 
 The Courier Node.js SDK provides typed access to the Courier REST API from server-side TypeScript or JavaScript. Use it to send notifications, manage user profiles, check message status, issue JWT tokens for client-side SDKs, and more.
@@ -62,4 +60,3 @@ Full documentation: **[courier.com/docs/sdk-libraries/node](https://www.courier.
 - [Quickstart](https://www.courier.com/docs/getting-started/quickstart/)
 - [Send API](https://www.courier.com/docs/platform/sending/send-message/)
 - [API Reference](https://www.courier.com/docs/reference/get-started/)
-<!-- AUTO-GENERATED-OVERVIEW:END -->

--- a/api.md
+++ b/api.md
@@ -269,6 +269,24 @@ Methods:
 - <code title="post /broadcasts/{broadcastId}/schedule">client.broadcasts.<a href="./src/resources/broadcasts.ts">schedule</a>(broadcastID, { ...params }) -> Broadcast</code>
 - <code title="post /broadcasts/{broadcastId}/send">client.broadcasts.<a href="./src/resources/broadcasts.ts">send</a>(broadcastID, { ...params }) -> Broadcast</code>
 
+# Bulk
+
+Types:
+
+- <code><a href="./src/resources/bulk.ts">InboundBulkMessage</a></code>
+- <code><a href="./src/resources/bulk.ts">InboundBulkMessageUser</a></code>
+- <code><a href="./src/resources/bulk.ts">BulkCreateJobResponse</a></code>
+- <code><a href="./src/resources/bulk.ts">BulkListUsersResponse</a></code>
+- <code><a href="./src/resources/bulk.ts">BulkRetrieveJobResponse</a></code>
+
+Methods:
+
+- <code title="post /bulk/{job_id}">client.bulk.<a href="./src/resources/bulk.ts">addUsers</a>(jobID, { ...params }) -> void</code>
+- <code title="post /bulk">client.bulk.<a href="./src/resources/bulk.ts">createJob</a>({ ...params }) -> BulkCreateJobResponse</code>
+- <code title="get /bulk/{job_id}/users">client.bulk.<a href="./src/resources/bulk.ts">listUsers</a>(jobID, { ...params }) -> BulkListUsersResponse</code>
+- <code title="get /bulk/{job_id}">client.bulk.<a href="./src/resources/bulk.ts">retrieveJob</a>(jobID) -> BulkRetrieveJobResponse</code>
+- <code title="post /bulk/{job_id}/run">client.bulk.<a href="./src/resources/bulk.ts">runJob</a>(jobID) -> void</code>
+
 # Brands
 
 Types:

--- a/bin/check-release-environment
+++ b/bin/check-release-environment
@@ -2,6 +2,10 @@
 
 errors=()
 
+if [ -z "${RELEASE_PLEASE_TOKEN}" ]; then
+  errors+=("The RELEASE_PLEASE_TOKEN secret has not been set. Create a fine-grained GitHub PAT and add it as a repository secret.")
+fi
+
 lenErrors=${#errors[@]}
 
 if [[ lenErrors -gt 0 ]]; then

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,7 +2,7 @@
   "packages": {
     ".": {}
   },
-  "$schema": "https://raw.githubusercontent.com/stainless-api/release-please/main/schemas/config.json",
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "versioning": "prerelease",

--- a/scripts/utils/upload-artifact.sh
+++ b/scripts/utils/upload-artifact.sh
@@ -20,7 +20,7 @@ UPLOAD_RESPONSE=$(curl -v -X PUT \
 
 if echo "$UPLOAD_RESPONSE" | grep -q "HTTP/[0-9.]* 200"; then
   echo -e "\033[32mUploaded build to Stainless storage.\033[0m"
-  echo -e "\033[32mInstallation: npm install 'https://pkg.stainless.com/s/courier-typescript/$SHA'\033[0m"
+  echo -e "\033[32mInstallation: npm install 'https://pkg.stainless.com/s/courier-node/$SHA'\033[0m"
 else
   echo -e "\033[31mFailed to upload artifact.\033[0m"
   exit 1

--- a/src/client.ts
+++ b/src/client.ts
@@ -72,6 +72,17 @@ import {
   SendBroadcastRequest,
   UpdateBroadcastRequest,
 } from './resources/broadcasts';
+import {
+  Bulk,
+  BulkAddUsersParams,
+  BulkCreateJobParams,
+  BulkCreateJobResponse,
+  BulkListUsersParams,
+  BulkListUsersResponse,
+  BulkRetrieveJobResponse,
+  InboundBulkMessage,
+  InboundBulkMessageUser,
+} from './resources/bulk';
 import { Inbound, InboundTrackEventParams, InboundTrackEventResponse } from './resources/inbound';
 import {
   MessageContentResponse,
@@ -1012,6 +1023,7 @@ export class Courier {
    * Create a one-off send to a list or audience, author its content, then send it immediately or schedule it for later.
    */
   broadcasts: API.Broadcasts = new API.Broadcasts(this);
+  bulk: API.Bulk = new API.Bulk(this);
   /**
    * Manage the logos, colors, and layout that give the templates you send a consistent look.
    */
@@ -1068,6 +1080,7 @@ Courier.Auth = Auth;
 Courier.Automations = Automations;
 Courier.Journeys = Journeys;
 Courier.Broadcasts = Broadcasts;
+Courier.Bulk = Bulk;
 Courier.Brands = Brands;
 Courier.Digests = Digests;
 Courier.Inbound = Inbound;
@@ -1197,6 +1210,18 @@ export declare namespace Courier {
     type BroadcastRetrieveContentParams as BroadcastRetrieveContentParams,
     type BroadcastScheduleParams as BroadcastScheduleParams,
     type BroadcastSendParams as BroadcastSendParams,
+  };
+
+  export {
+    Bulk as Bulk,
+    type InboundBulkMessage as InboundBulkMessage,
+    type InboundBulkMessageUser as InboundBulkMessageUser,
+    type BulkCreateJobResponse as BulkCreateJobResponse,
+    type BulkListUsersResponse as BulkListUsersResponse,
+    type BulkRetrieveJobResponse as BulkRetrieveJobResponse,
+    type BulkAddUsersParams as BulkAddUsersParams,
+    type BulkCreateJobParams as BulkCreateJobParams,
+    type BulkListUsersParams as BulkListUsersParams,
   };
 
   export {

--- a/src/resources/bulk.ts
+++ b/src/resources/bulk.ts
@@ -1,0 +1,210 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import { APIResource } from '../core/resource';
+import * as BulkAPI from './bulk';
+import * as Shared from './shared';
+import { APIPromise } from '../core/api-promise';
+import { buildHeaders } from '../internal/headers';
+import { RequestOptions } from '../internal/request-options';
+import { path } from '../internal/utils/path';
+
+export class Bulk extends APIResource {
+  /**
+   * Ingest user data into a Bulk Job.
+   *
+   * **Important**: For email-based bulk jobs, each user must include `profile.email`
+   * for provider routing to work correctly. The `to.email` field is not sufficient
+   * for email provider routing.
+   */
+  addUsers(jobID: string, body: BulkAddUsersParams, options?: RequestOptions): APIPromise<void> {
+    return this._client.post(path`/bulk/${jobID}`, {
+      body,
+      ...options,
+      headers: buildHeaders([{ Accept: '*/*' }, options?.headers]),
+    });
+  }
+
+  /**
+   * Creates a new bulk job for sending messages to multiple recipients.
+   *
+   * **Required**: `message.event` (event ID or notification ID)
+   *
+   * **Optional (V2 format)**: `message.template` (notification ID) or
+   * `message.content` (Elemental content) can be provided to override the
+   * notification associated with the event.
+   */
+  createJob(body: BulkCreateJobParams, options?: RequestOptions): APIPromise<BulkCreateJobResponse> {
+    return this._client.post('/bulk', { body, ...options });
+  }
+
+  /**
+   * Get Bulk Job Users
+   */
+  listUsers(
+    jobID: string,
+    query: BulkListUsersParams | null | undefined = {},
+    options?: RequestOptions,
+  ): APIPromise<BulkListUsersResponse> {
+    return this._client.get(path`/bulk/${jobID}/users`, { query, ...options });
+  }
+
+  /**
+   * Get a bulk job
+   */
+  retrieveJob(jobID: string, options?: RequestOptions): APIPromise<BulkRetrieveJobResponse> {
+    return this._client.get(path`/bulk/${jobID}`, options);
+  }
+
+  /**
+   * Run a bulk job
+   */
+  runJob(jobID: string, options?: RequestOptions): APIPromise<void> {
+    return this._client.post(path`/bulk/${jobID}/run`, {
+      ...options,
+      headers: buildHeaders([{ Accept: '*/*' }, options?.headers]),
+    });
+  }
+}
+
+/**
+ * Bulk message definition. Supports two formats:
+ *
+ * - V1 format: Requires `event` field (event ID or notification ID)
+ * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+ *   content) in addition to `event`
+ */
+export interface InboundBulkMessage {
+  /**
+   * Event ID or Notification ID (required). Can be either a Notification ID (e.g.,
+   * "FRH3QXM9E34W4RKP7MRC8NZ1T8V8") or a custom Event ID (e.g., "welcome-email")
+   * mapped to a notification.
+   */
+  event: string;
+
+  brand?: string | null;
+
+  /**
+   * Elemental content (optional, for V2 format). When provided, this will be used
+   * instead of the notification associated with the `event` field.
+   */
+  content?: Shared.ElementalContentSugar | Shared.ElementalContent | null;
+
+  data?: { [key: string]: unknown } | null;
+
+  locale?: { [key: string]: { [key: string]: unknown } } | null;
+
+  override?: { [key: string]: unknown } | null;
+
+  /**
+   * Notification ID or template ID (optional, for V2 format). When provided, this
+   * will be used instead of the notification associated with the `event` field.
+   */
+  template?: string | null;
+}
+
+export interface InboundBulkMessageUser {
+  /**
+   * User-specific data that will be merged with message.data
+   */
+  data?: unknown;
+
+  preferences?: Shared.RecipientPreferences | null;
+
+  /**
+   * User profile information. For email-based bulk jobs, `profile.email` is required
+   * for provider routing to determine if the message can be delivered. The email
+   * address should be provided here rather than in `to.email`.
+   */
+  profile?: { [key: string]: unknown } | null;
+
+  /**
+   * User ID (legacy field, use profile or to.user_id instead)
+   */
+  recipient?: string | null;
+
+  /**
+   * Optional recipient information. Note: For email provider routing, use
+   * `profile.email` instead of `to.email`. The `to` field is primarily used for
+   * recipient identification and data merging.
+   */
+  to?: Shared.UserRecipient | null;
+}
+
+export interface BulkCreateJobResponse {
+  jobId: string;
+}
+
+export interface BulkListUsersResponse {
+  items: Array<BulkListUsersResponse.Item>;
+
+  paging: Shared.Paging;
+}
+
+export namespace BulkListUsersResponse {
+  export interface Item extends BulkAPI.InboundBulkMessageUser {
+    status: 'PENDING' | 'ENQUEUED' | 'ERROR';
+
+    messageId?: string | null;
+  }
+}
+
+export interface BulkRetrieveJobResponse {
+  job: BulkRetrieveJobResponse.Job;
+}
+
+export namespace BulkRetrieveJobResponse {
+  export interface Job {
+    /**
+     * Bulk message definition. Supports two formats:
+     *
+     * - V1 format: Requires `event` field (event ID or notification ID)
+     * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+     *   content) in addition to `event`
+     */
+    definition: BulkAPI.InboundBulkMessage;
+
+    enqueued: number;
+
+    failures: number;
+
+    received: number;
+
+    status: 'CREATED' | 'PROCESSING' | 'COMPLETED' | 'ERROR';
+  }
+}
+
+export interface BulkAddUsersParams {
+  users: Array<InboundBulkMessageUser>;
+}
+
+export interface BulkCreateJobParams {
+  /**
+   * Bulk message definition. Supports two formats:
+   *
+   * - V1 format: Requires `event` field (event ID or notification ID)
+   * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+   *   content) in addition to `event`
+   */
+  message: InboundBulkMessage;
+}
+
+export interface BulkListUsersParams {
+  /**
+   * A unique identifier that allows for fetching the next set of users added to the
+   * bulk job
+   */
+  cursor?: string | null;
+}
+
+export declare namespace Bulk {
+  export {
+    type InboundBulkMessage as InboundBulkMessage,
+    type InboundBulkMessageUser as InboundBulkMessageUser,
+    type BulkCreateJobResponse as BulkCreateJobResponse,
+    type BulkListUsersResponse as BulkListUsersResponse,
+    type BulkRetrieveJobResponse as BulkRetrieveJobResponse,
+    type BulkAddUsersParams as BulkAddUsersParams,
+    type BulkCreateJobParams as BulkCreateJobParams,
+    type BulkListUsersParams as BulkListUsersParams,
+  };
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -64,6 +64,17 @@ export {
   type BroadcastSendParams,
 } from './broadcasts';
 export {
+  Bulk,
+  type InboundBulkMessage,
+  type InboundBulkMessageUser,
+  type BulkCreateJobResponse,
+  type BulkListUsersResponse,
+  type BulkRetrieveJobResponse,
+  type BulkAddUsersParams,
+  type BulkCreateJobParams,
+  type BulkListUsersParams,
+} from './bulk';
+export {
   Digests,
   type DigestCategory,
   type DigestInstance,

--- a/src/resources/send.ts
+++ b/src/resources/send.ts
@@ -12,7 +12,8 @@ import { RequestOptions } from '../internal/request-options';
 export class Send extends APIResource {
   /**
    * Sends a message to one or more recipients and returns a requestId. Courier
-   * routes it to email, SMS, push, chat, or in-app based on your rules.
+   * routes it to email, SMS, push, chat, or in-app based on your rules. Use the
+   * returned requestId to look up delivery status via the Messages API.
    *
    * @example
    * ```ts

--- a/tests/api-resources/bulk.test.ts
+++ b/tests/api-resources/bulk.test.ts
@@ -1,0 +1,152 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import Courier from '@trycourier/courier';
+
+const client = new Courier({
+  apiKey: 'My API Key',
+  baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
+});
+
+describe('resource bulk', () => {
+  // Mock server tests are disabled
+  test.skip('addUsers: only required params', async () => {
+    const responsePromise = client.bulk.addUsers('job_id', { users: [{}] });
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // Mock server tests are disabled
+  test.skip('addUsers: required and optional params', async () => {
+    const response = await client.bulk.addUsers('job_id', {
+      users: [
+        {
+          data: {},
+          preferences: {
+            categories: {
+              foo: {
+                status: 'OPTED_IN',
+                channel_preferences: [{ channel: 'direct_message' }],
+                rules: [{ until: 'until', start: 'start' }],
+              },
+            },
+            notifications: {
+              foo: {
+                status: 'OPTED_IN',
+                channel_preferences: [{ channel: 'direct_message' }],
+                rules: [{ until: 'until', start: 'start' }],
+              },
+            },
+          },
+          profile: { foo: 'bar' },
+          recipient: 'recipient',
+          to: {
+            account_id: 'account_id',
+            context: { tenant_id: 'tenant_id' },
+            data: { foo: 'bar' },
+            email: 'email',
+            list_id: 'list_id',
+            locale: 'locale',
+            phone_number: 'phone_number',
+            preferences: {
+              notifications: {
+                foo: {
+                  status: 'OPTED_IN',
+                  channel_preferences: [{ channel: 'direct_message' }],
+                  rules: [{ until: 'until', start: 'start' }],
+                  source: 'subscription',
+                },
+              },
+              categories: {
+                foo: {
+                  status: 'OPTED_IN',
+                  channel_preferences: [{ channel: 'direct_message' }],
+                  rules: [{ until: 'until', start: 'start' }],
+                  source: 'subscription',
+                },
+              },
+              templateId: 'templateId',
+            },
+            tenant_id: 'tenant_id',
+            user_id: 'user_id',
+          },
+        },
+      ],
+    });
+  });
+
+  // Mock server tests are disabled
+  test.skip('createJob: only required params', async () => {
+    const responsePromise = client.bulk.createJob({ message: { event: 'event' } });
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // Mock server tests are disabled
+  test.skip('createJob: required and optional params', async () => {
+    const response = await client.bulk.createJob({
+      message: {
+        event: 'event',
+        brand: 'brand',
+        content: { body: 'body', title: 'title' },
+        data: { foo: 'bar' },
+        locale: { foo: { foo: 'bar' } },
+        override: { foo: 'bar' },
+        template: 'template',
+      },
+    });
+  });
+
+  // Mock server tests are disabled
+  test.skip('listUsers', async () => {
+    const responsePromise = client.bulk.listUsers('job_id');
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // Mock server tests are disabled
+  test.skip('listUsers: request options and params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.bulk.listUsers('job_id', { cursor: 'cursor' }, { path: '/_stainless_unknown_path' }),
+    ).rejects.toThrow(Courier.NotFoundError);
+  });
+
+  // Mock server tests are disabled
+  test.skip('retrieveJob', async () => {
+    const responsePromise = client.bulk.retrieveJob('job_id');
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // Mock server tests are disabled
+  test.skip('runJob', async () => {
+    const responsePromise = client.bulk.runJob('job_id');
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+});


### PR DESCRIPTION
Superseded. This branch is retired in favour of `sdk-sync`; a fresh PR will open there on the next specification change.