### PR TITLE
docs: sync README from api-spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-<!-- AUTO-GENERATED-OVERVIEW:START — Do not edit this section. It is synced from mintlify-docs. -->
-
 # Courier Node.js SDK
 
 The Courier Node.js SDK provides typed access to the Courier REST API from server-side TypeScript or JavaScript. Use it to send notifications, manage user profiles, check message status, issue JWT tokens for client-side SDKs, and more.
@@ -62,4 +60,3 @@ Full documentation: **[courier.com/docs/sdk-libraries/node](https://www.courier.
 - [Quickstart](https://www.courier.com/docs/getting-started/quickstart/)
 - [Send API](https://www.courier.com/docs/platform/sending/send-message/)
 - [API Reference](https://www.courier.com/docs/reference/get-started/)
-<!-- AUTO-GENERATED-OVERVIEW:END -->


### PR DESCRIPTION
Takes ownership of this README in the SDK repo.

`trycourier/api-spec` used to overwrite it on every spec merge, from its own `READMEs/<target>.md` overlay. That overlay is being removed (trycourier/api-spec#200) — kits are now generated SDK source only, and `README.md` is pruned from them. This lands the api-spec copy here once so nothing is lost, and from now on **this repo owns its README**.

Two notes:

- The `AUTO-GENERATED-OVERVIEW` markers are dropped. They claimed the file was synced from mintlify-docs, but `mintlify-docs/sdk-libraries/readme-exports/readme-sync-map.json` targets only the web and mobile SDKs — never this repo. Nothing has been rewriting them, and the banner told maintainers not to edit a file they in fact own.
- Where the install snippet carries a version, it is wrapped in `x-release-please-start-version` markers so release-please keeps it current on each release (this repo already lists `README.md` in its `extra-files`).

Review the content as a normal docs change — if the previous version read better in places, keep those parts.