### PR TITLE
chore(api): regenerate SDK

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,4 +1,1 @@
-configured_endpoints: 145
-openapi_spec_url: https://storage.googleapis.com/stainless-sdk-openapi-specs/courier/courier-82881993f19c5fac9ac662f1a516e5b54bd7c6655d07f29a3779dfb0286cafd3.yml
-openapi_spec_hash: 92f4c510a5a15d091036d70caa8ee573
-config_hash: 768b0f5ada2bf01cf2659d5dbbad1fa0
+configured_endpoints: 150

--- a/api.md
+++ b/api.md
@@ -269,6 +269,24 @@ Methods:
 - <code title="post /broadcasts/{broadcastId}/schedule">client.broadcasts.<a href="./src/resources/broadcasts.ts">schedule</a>(broadcastID, { ...params }) -> Broadcast</code>
 - <code title="post /broadcasts/{broadcastId}/send">client.broadcasts.<a href="./src/resources/broadcasts.ts">send</a>(broadcastID, { ...params }) -> Broadcast</code>
 
+# Bulk
+
+Types:
+
+- <code><a href="./src/resources/bulk.ts">InboundBulkMessage</a></code>
+- <code><a href="./src/resources/bulk.ts">InboundBulkMessageUser</a></code>
+- <code><a href="./src/resources/bulk.ts">BulkCreateJobResponse</a></code>
+- <code><a href="./src/resources/bulk.ts">BulkListUsersResponse</a></code>
+- <code><a href="./src/resources/bulk.ts">BulkRetrieveJobResponse</a></code>
+
+Methods:
+
+- <code title="post /bulk/{job_id}">client.bulk.<a href="./src/resources/bulk.ts">addUsers</a>(jobID, { ...params }) -> void</code>
+- <code title="post /bulk">client.bulk.<a href="./src/resources/bulk.ts">createJob</a>({ ...params }) -> BulkCreateJobResponse</code>
+- <code title="get /bulk/{job_id}/users">client.bulk.<a href="./src/resources/bulk.ts">listUsers</a>(jobID, { ...params }) -> BulkListUsersResponse</code>
+- <code title="get /bulk/{job_id}">client.bulk.<a href="./src/resources/bulk.ts">retrieveJob</a>(jobID) -> BulkRetrieveJobResponse</code>
+- <code title="post /bulk/{job_id}/run">client.bulk.<a href="./src/resources/bulk.ts">runJob</a>(jobID) -> void</code>
+
 # Brands
 
 Types:

--- a/src/client.ts
+++ b/src/client.ts
@@ -72,6 +72,17 @@ import {
   SendBroadcastRequest,
   UpdateBroadcastRequest,
 } from './resources/broadcasts';
+import {
+  Bulk,
+  BulkAddUsersParams,
+  BulkCreateJobParams,
+  BulkCreateJobResponse,
+  BulkListUsersParams,
+  BulkListUsersResponse,
+  BulkRetrieveJobResponse,
+  InboundBulkMessage,
+  InboundBulkMessageUser,
+} from './resources/bulk';
 import { Inbound, InboundTrackEventParams, InboundTrackEventResponse } from './resources/inbound';
 import {
   MessageContentResponse,
@@ -1012,6 +1023,7 @@ export class Courier {
    * Create a one-off send to a list or audience, author its content, then send it immediately or schedule it for later.
    */
   broadcasts: API.Broadcasts = new API.Broadcasts(this);
+  bulk: API.Bulk = new API.Bulk(this);
   /**
    * Manage the logos, colors, and layout that give the templates you send a consistent look.
    */
@@ -1068,6 +1080,7 @@ Courier.Auth = Auth;
 Courier.Automations = Automations;
 Courier.Journeys = Journeys;
 Courier.Broadcasts = Broadcasts;
+Courier.Bulk = Bulk;
 Courier.Brands = Brands;
 Courier.Digests = Digests;
 Courier.Inbound = Inbound;
@@ -1197,6 +1210,18 @@ export declare namespace Courier {
     type BroadcastRetrieveContentParams as BroadcastRetrieveContentParams,
     type BroadcastScheduleParams as BroadcastScheduleParams,
     type BroadcastSendParams as BroadcastSendParams,
+  };
+
+  export {
+    Bulk as Bulk,
+    type InboundBulkMessage as InboundBulkMessage,
+    type InboundBulkMessageUser as InboundBulkMessageUser,
+    type BulkCreateJobResponse as BulkCreateJobResponse,
+    type BulkListUsersResponse as BulkListUsersResponse,
+    type BulkRetrieveJobResponse as BulkRetrieveJobResponse,
+    type BulkAddUsersParams as BulkAddUsersParams,
+    type BulkCreateJobParams as BulkCreateJobParams,
+    type BulkListUsersParams as BulkListUsersParams,
   };
 
   export {

--- a/src/resources/bulk.ts
+++ b/src/resources/bulk.ts
@@ -1,0 +1,210 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import { APIResource } from '../core/resource';
+import * as BulkAPI from './bulk';
+import * as Shared from './shared';
+import { APIPromise } from '../core/api-promise';
+import { buildHeaders } from '../internal/headers';
+import { RequestOptions } from '../internal/request-options';
+import { path } from '../internal/utils/path';
+
+export class Bulk extends APIResource {
+  /**
+   * Ingest user data into a Bulk Job.
+   *
+   * **Important**: For email-based bulk jobs, each user must include `profile.email`
+   * for provider routing to work correctly. The `to.email` field is not sufficient
+   * for email provider routing.
+   */
+  addUsers(jobID: string, body: BulkAddUsersParams, options?: RequestOptions): APIPromise<void> {
+    return this._client.post(path`/bulk/${jobID}`, {
+      body,
+      ...options,
+      headers: buildHeaders([{ Accept: '*/*' }, options?.headers]),
+    });
+  }
+
+  /**
+   * Creates a new bulk job for sending messages to multiple recipients.
+   *
+   * **Required**: `message.event` (event ID or notification ID)
+   *
+   * **Optional (V2 format)**: `message.template` (notification ID) or
+   * `message.content` (Elemental content) can be provided to override the
+   * notification associated with the event.
+   */
+  createJob(body: BulkCreateJobParams, options?: RequestOptions): APIPromise<BulkCreateJobResponse> {
+    return this._client.post('/bulk', { body, ...options });
+  }
+
+  /**
+   * Get Bulk Job Users
+   */
+  listUsers(
+    jobID: string,
+    query: BulkListUsersParams | null | undefined = {},
+    options?: RequestOptions,
+  ): APIPromise<BulkListUsersResponse> {
+    return this._client.get(path`/bulk/${jobID}/users`, { query, ...options });
+  }
+
+  /**
+   * Get a bulk job
+   */
+  retrieveJob(jobID: string, options?: RequestOptions): APIPromise<BulkRetrieveJobResponse> {
+    return this._client.get(path`/bulk/${jobID}`, options);
+  }
+
+  /**
+   * Run a bulk job
+   */
+  runJob(jobID: string, options?: RequestOptions): APIPromise<void> {
+    return this._client.post(path`/bulk/${jobID}/run`, {
+      ...options,
+      headers: buildHeaders([{ Accept: '*/*' }, options?.headers]),
+    });
+  }
+}
+
+/**
+ * Bulk message definition. Supports two formats:
+ *
+ * - V1 format: Requires `event` field (event ID or notification ID)
+ * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+ *   content) in addition to `event`
+ */
+export interface InboundBulkMessage {
+  /**
+   * Event ID or Notification ID (required). Can be either a Notification ID (e.g.,
+   * "FRH3QXM9E34W4RKP7MRC8NZ1T8V8") or a custom Event ID (e.g., "welcome-email")
+   * mapped to a notification.
+   */
+  event: string;
+
+  brand?: string | null;
+
+  /**
+   * Elemental content (optional, for V2 format). When provided, this will be used
+   * instead of the notification associated with the `event` field.
+   */
+  content?: Shared.ElementalContentSugar | Shared.ElementalContent | null;
+
+  data?: { [key: string]: unknown } | null;
+
+  locale?: { [key: string]: { [key: string]: unknown } } | null;
+
+  override?: { [key: string]: unknown } | null;
+
+  /**
+   * Notification ID or template ID (optional, for V2 format). When provided, this
+   * will be used instead of the notification associated with the `event` field.
+   */
+  template?: string | null;
+}
+
+export interface InboundBulkMessageUser {
+  /**
+   * User-specific data that will be merged with message.data
+   */
+  data?: unknown;
+
+  preferences?: Shared.RecipientPreferences | null;
+
+  /**
+   * User profile information. For email-based bulk jobs, `profile.email` is required
+   * for provider routing to determine if the message can be delivered. The email
+   * address should be provided here rather than in `to.email`.
+   */
+  profile?: { [key: string]: unknown } | null;
+
+  /**
+   * User ID (legacy field, use profile or to.user_id instead)
+   */
+  recipient?: string | null;
+
+  /**
+   * Optional recipient information. Note: For email provider routing, use
+   * `profile.email` instead of `to.email`. The `to` field is primarily used for
+   * recipient identification and data merging.
+   */
+  to?: Shared.UserRecipient | null;
+}
+
+export interface BulkCreateJobResponse {
+  jobId: string;
+}
+
+export interface BulkListUsersResponse {
+  items: Array<BulkListUsersResponse.Item>;
+
+  paging: Shared.Paging;
+}
+
+export namespace BulkListUsersResponse {
+  export interface Item extends BulkAPI.InboundBulkMessageUser {
+    status: 'PENDING' | 'ENQUEUED' | 'ERROR';
+
+    messageId?: string | null;
+  }
+}
+
+export interface BulkRetrieveJobResponse {
+  job: BulkRetrieveJobResponse.Job;
+}
+
+export namespace BulkRetrieveJobResponse {
+  export interface Job {
+    /**
+     * Bulk message definition. Supports two formats:
+     *
+     * - V1 format: Requires `event` field (event ID or notification ID)
+     * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+     *   content) in addition to `event`
+     */
+    definition: BulkAPI.InboundBulkMessage;
+
+    enqueued: number;
+
+    failures: number;
+
+    received: number;
+
+    status: 'CREATED' | 'PROCESSING' | 'COMPLETED' | 'ERROR';
+  }
+}
+
+export interface BulkAddUsersParams {
+  users: Array<InboundBulkMessageUser>;
+}
+
+export interface BulkCreateJobParams {
+  /**
+   * Bulk message definition. Supports two formats:
+   *
+   * - V1 format: Requires `event` field (event ID or notification ID)
+   * - V2 format: Optionally use `template` (notification ID) or `content` (Elemental
+   *   content) in addition to `event`
+   */
+  message: InboundBulkMessage;
+}
+
+export interface BulkListUsersParams {
+  /**
+   * A unique identifier that allows for fetching the next set of users added to the
+   * bulk job
+   */
+  cursor?: string | null;
+}
+
+export declare namespace Bulk {
+  export {
+    type InboundBulkMessage as InboundBulkMessage,
+    type InboundBulkMessageUser as InboundBulkMessageUser,
+    type BulkCreateJobResponse as BulkCreateJobResponse,
+    type BulkListUsersResponse as BulkListUsersResponse,
+    type BulkRetrieveJobResponse as BulkRetrieveJobResponse,
+    type BulkAddUsersParams as BulkAddUsersParams,
+    type BulkCreateJobParams as BulkCreateJobParams,
+    type BulkListUsersParams as BulkListUsersParams,
+  };
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -64,6 +64,17 @@ export {
   type BroadcastSendParams,
 } from './broadcasts';
 export {
+  Bulk,
+  type InboundBulkMessage,
+  type InboundBulkMessageUser,
+  type BulkCreateJobResponse,
+  type BulkListUsersResponse,
+  type BulkRetrieveJobResponse,
+  type BulkAddUsersParams,
+  type BulkCreateJobParams,
+  type BulkListUsersParams,
+} from './bulk';
+export {
   Digests,
   type DigestCategory,
   type DigestInstance,

--- a/src/resources/send.ts
+++ b/src/resources/send.ts
@@ -12,7 +12,8 @@ import { RequestOptions } from '../internal/request-options';
 export class Send extends APIResource {
   /**
    * Sends a message to one or more recipients and returns a requestId. Courier
-   * routes it to email, SMS, push, chat, or in-app based on your rules.
+   * routes it to email, SMS, push, chat, or in-app based on your rules. Use the
+   * returned requestId to look up delivery status via the Messages API.
    *
    * @example
    * ```ts

--- a/tests/api-resources/bulk.test.ts
+++ b/tests/api-resources/bulk.test.ts
@@ -1,0 +1,152 @@
+// File generated from our OpenAPI spec by Stainless. See CONTRIBUTING.md for details.
+
+import Courier from '@trycourier/courier';
+
+const client = new Courier({
+  apiKey: 'My API Key',
+  baseURL: process.env['TEST_API_BASE_URL'] ?? 'http://127.0.0.1:4010',
+});
+
+describe('resource bulk', () => {
+  // Mock server tests are disabled
+  test.skip('addUsers: only required params', async () => {
+    const responsePromise = client.bulk.addUsers('job_id', { users: [{}] });
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // Mock server tests are disabled
+  test.skip('addUsers: required and optional params', async () => {
+    const response = await client.bulk.addUsers('job_id', {
+      users: [
+        {
+          data: {},
+          preferences: {
+            categories: {
+              foo: {
+                status: 'OPTED_IN',
+                channel_preferences: [{ channel: 'direct_message' }],
+                rules: [{ until: 'until', start: 'start' }],
+              },
+            },
+            notifications: {
+              foo: {
+                status: 'OPTED_IN',
+                channel_preferences: [{ channel: 'direct_message' }],
+                rules: [{ until: 'until', start: 'start' }],
+              },
+            },
+          },
+          profile: { foo: 'bar' },
+          recipient: 'recipient',
+          to: {
+            account_id: 'account_id',
+            context: { tenant_id: 'tenant_id' },
+            data: { foo: 'bar' },
+            email: 'email',
+            list_id: 'list_id',
+            locale: 'locale',
+            phone_number: 'phone_number',
+            preferences: {
+              notifications: {
+                foo: {
+                  status: 'OPTED_IN',
+                  channel_preferences: [{ channel: 'direct_message' }],
+                  rules: [{ until: 'until', start: 'start' }],
+                  source: 'subscription',
+                },
+              },
+              categories: {
+                foo: {
+                  status: 'OPTED_IN',
+                  channel_preferences: [{ channel: 'direct_message' }],
+                  rules: [{ until: 'until', start: 'start' }],
+                  source: 'subscription',
+                },
+              },
+              templateId: 'templateId',
+            },
+            tenant_id: 'tenant_id',
+            user_id: 'user_id',
+          },
+        },
+      ],
+    });
+  });
+
+  // Mock server tests are disabled
+  test.skip('createJob: only required params', async () => {
+    const responsePromise = client.bulk.createJob({ message: { event: 'event' } });
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // Mock server tests are disabled
+  test.skip('createJob: required and optional params', async () => {
+    const response = await client.bulk.createJob({
+      message: {
+        event: 'event',
+        brand: 'brand',
+        content: { body: 'body', title: 'title' },
+        data: { foo: 'bar' },
+        locale: { foo: { foo: 'bar' } },
+        override: { foo: 'bar' },
+        template: 'template',
+      },
+    });
+  });
+
+  // Mock server tests are disabled
+  test.skip('listUsers', async () => {
+    const responsePromise = client.bulk.listUsers('job_id');
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // Mock server tests are disabled
+  test.skip('listUsers: request options and params are passed correctly', async () => {
+    // ensure the request options are being passed correctly by passing an invalid HTTP method in order to cause an error
+    await expect(
+      client.bulk.listUsers('job_id', { cursor: 'cursor' }, { path: '/_stainless_unknown_path' }),
+    ).rejects.toThrow(Courier.NotFoundError);
+  });
+
+  // Mock server tests are disabled
+  test.skip('retrieveJob', async () => {
+    const responsePromise = client.bulk.retrieveJob('job_id');
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+
+  // Mock server tests are disabled
+  test.skip('runJob', async () => {
+    const responsePromise = client.bulk.runJob('job_id');
+    const rawResponse = await responsePromise.asResponse();
+    expect(rawResponse).toBeInstanceOf(Response);
+    const response = await responsePromise;
+    expect(response).not.toBeInstanceOf(Response);
+    const dataAndResponse = await responsePromise.withResponse();
+    expect(dataAndResponse.data).toBe(response);
+    expect(dataAndResponse.response).toBe(rawResponse);
+  });
+});


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

7 files changed, 419 insertions(+), 5 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml                       |   5 +-
 api.md                           |  18 +++++
 src/client.ts                    |  25 +++++++
 src/resources/bulk.ts            | 210 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 src/resources/index.ts           |  11 ++++
 src/resources/send.ts            |   3 +-
 tests/api-resources/bulk.test.ts | 152 ++++++++++++++++++++++++++++++++++++++++++
 7 files changed, 419 insertions(+), 5 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
