### PR TITLE
docs(api): give every request body an example, and correct the archive status code

### DIFF
--- a/src/resources/audiences.ts
+++ b/src/resources/audiences.ts
@@ -14,6 +14,13 @@ export class Audiences extends APIResource {
   /**
    * Returns one audience with its name, description, and the filter and AND or OR
    * operator that decide which users belong to it.
+   *
+   * @example
+   * ```ts
+   * const audience = await client.audiences.retrieve(
+   *   'audience_id',
+   * );
+   * ```
    */
   retrieve(audienceID: string, options?: RequestOptions): APIPromise<Audience> {
     return this._client.get(path`/audiences/${audienceID}`, options);
@@ -22,6 +29,28 @@ export class Audiences extends APIResource {
   /**
    * Creates or replaces an audience from a filter and an AND or OR operator.
    * Membership recalculates automatically as profiles change.
+   *
+   * @example
+   * ```ts
+   * const audience = await client.audiences.update(
+   *   'audience_id',
+   *   {
+   *     description: 'Users located in the US',
+   *     filter: {
+   *       operator: 'AND',
+   *       filters: [
+   *         {
+   *           operator: 'EQ',
+   *           path: 'profile.location',
+   *           value: 'US',
+   *         },
+   *       ],
+   *     },
+   *     name: 'Engaged US Users',
+   *     operator: 'AND',
+   *   },
+   * );
+   * ```
    */
   update(
     audienceID: string,
@@ -34,6 +63,11 @@ export class Audiences extends APIResource {
   /**
    * Returns the audiences in the workspace with paging. Audiences are filter-based
    * groups that recalculate as user profiles change.
+   *
+   * @example
+   * ```ts
+   * const audiences = await client.audiences.list();
+   * ```
    */
   list(
     query: AudienceListParams | null | undefined = {},
@@ -45,6 +79,11 @@ export class Audiences extends APIResource {
   /**
    * Deletes an audience permanently, so update any caller sending to it by audience
    * id first. Those sends fail once the audience is gone.
+   *
+   * @example
+   * ```ts
+   * await client.audiences.delete('audience_id');
+   * ```
    */
   delete(audienceID: string, options?: RequestOptions): APIPromise<void> {
     return this._client.delete(path`/audiences/${audienceID}`, {
@@ -56,6 +95,13 @@ export class Audiences extends APIResource {
   /**
    * Returns the users currently matching an audience filter, with paging. Membership
    * is recalculated, so results shift as profiles change.
+   *
+   * @example
+   * ```ts
+   * const response = await client.audiences.listMembers(
+   *   'audience_id',
+   * );
+   * ```
    */
   listMembers(
     audienceID: string,

--- a/src/resources/automations/invoke.ts
+++ b/src/resources/automations/invoke.ts
@@ -68,7 +68,11 @@ export class Invoke extends APIResource {
    * const automationInvokeResponse =
    *   await client.automations.invoke.invokeByTemplate(
    *     'templateId',
-   *     { recipient: 'recipient' },
+   *     {
+   *       recipient: 'user_abc',
+   *       data: { orderId: '1234' },
+   *       profile: { email: 'jdoe@example.com' },
+   *     },
    *   );
    * ```
    */

--- a/src/resources/brands.ts
+++ b/src/resources/brands.ts
@@ -67,7 +67,10 @@ export class Brands extends APIResource {
    * @example
    * ```ts
    * const brand = await client.brands.update('brand_id', {
-   *   name: 'name',
+   *   name: 'My Brand',
+   *   settings: {
+   *     colors: { primary: '#9D3789', secondary: '#FFFFFF' },
+   *   },
    * });
    * ```
    */

--- a/src/resources/bulk.ts
+++ b/src/resources/bulk.ts
@@ -15,6 +15,19 @@ export class Bulk extends APIResource {
    * **Important**: For email-based bulk jobs, each user must include `profile.email`
    * for provider routing to work correctly. The `to.email` field is not sufficient
    * for email provider routing.
+   *
+   * @example
+   * ```ts
+   * await client.bulk.addUsers('job_id', {
+   *   users: [
+   *     {
+   *       recipient: 'user_abc',
+   *       profile: { email: 'jdoe@example.com' },
+   *       data: { name: 'Jane' },
+   *     },
+   *   ],
+   * });
+   * ```
    */
   addUsers(jobID: string, body: BulkAddUsersParams, options?: RequestOptions): APIPromise<void> {
     return this._client.post(path`/bulk/${jobID}`, {
@@ -32,6 +45,17 @@ export class Bulk extends APIResource {
    * **Optional (V2 format)**: `message.template` (notification ID) or
    * `message.content` (Elemental content) can be provided to override the
    * notification associated with the event.
+   *
+   * @example
+   * ```ts
+   * const response = await client.bulk.createJob({
+   *   message: {
+   *     event: 'welcome-series',
+   *     brand: 'bnd_01kx4mrd0pfzw8wt7pn7p2fzag',
+   *     data: { campaign: 'spring-2024' },
+   *   },
+   * });
+   * ```
    */
   createJob(body: BulkCreateJobParams, options?: RequestOptions): APIPromise<BulkCreateJobResponse> {
     return this._client.post('/bulk', { body, ...options });
@@ -39,6 +63,11 @@ export class Bulk extends APIResource {
 
   /**
    * Get Bulk Job Users
+   *
+   * @example
+   * ```ts
+   * const response = await client.bulk.listUsers('job_id');
+   * ```
    */
   listUsers(
     jobID: string,
@@ -50,6 +79,11 @@ export class Bulk extends APIResource {
 
   /**
    * Get a bulk job
+   *
+   * @example
+   * ```ts
+   * const response = await client.bulk.retrieveJob('job_id');
+   * ```
    */
   retrieveJob(jobID: string, options?: RequestOptions): APIPromise<BulkRetrieveJobResponse> {
     return this._client.get(path`/bulk/${jobID}`, options);
@@ -57,6 +91,11 @@ export class Bulk extends APIResource {
 
   /**
    * Run a bulk job
+   *
+   * @example
+   * ```ts
+   * await client.bulk.runJob('job_id');
+   * ```
    */
   runJob(jobID: string, options?: RequestOptions): APIPromise<void> {
     return this._client.post(path`/bulk/${jobID}/run`, {

--- a/src/resources/lists/lists.ts
+++ b/src/resources/lists/lists.ts
@@ -44,7 +44,9 @@ export class Lists extends APIResource {
    *
    * @example
    * ```ts
-   * await client.lists.update('list_id', { name: 'name' });
+   * await client.lists.update('list_id', {
+   *   name: 'Product Updates',
+   * });
    * ```
    */
   update(listID: string, body: ListUpdateParams, options?: RequestOptions): APIPromise<void> {

--- a/src/resources/lists/subscriptions.ts
+++ b/src/resources/lists/subscriptions.ts
@@ -38,7 +38,10 @@ export class Subscriptions extends APIResource {
    * @example
    * ```ts
    * await client.lists.subscriptions.add('list_id', {
-   *   recipients: [{ recipientId: 'recipientId' }],
+   *   recipients: [
+   *     { recipientId: 'user_abc' },
+   *     { recipientId: 'user_def' },
+   *   ],
    * });
    * ```
    */
@@ -71,7 +74,10 @@ export class Subscriptions extends APIResource {
    * @example
    * ```ts
    * await client.lists.subscriptions.subscribe('list_id', {
-   *   recipients: [{ recipientId: 'recipientId' }],
+   *   recipients: [
+   *     { recipientId: 'user_abc' },
+   *     { recipientId: 'user_def' },
+   *   ],
    * });
    * ```
    */
@@ -91,6 +97,11 @@ export class Subscriptions extends APIResource {
    * ```ts
    * await client.lists.subscriptions.subscribeUser('user_id', {
    *   list_id: 'list_id',
+   *   preferences: {
+   *     notifications: {
+   *       nt_01kx4h2jdafq8bk9aftxak4b40: { status: 'OPTED_IN' },
+   *     },
+   *   },
    * });
    * ```
    */

--- a/src/resources/notifications/checks.ts
+++ b/src/resources/notifications/checks.ts
@@ -23,9 +23,9 @@ export class Checks extends APIResource {
    *     id: 'id',
    *     checks: [
    *       {
-   *         id: 'id',
-   *         status: 'RESOLVED',
+   *         id: 'abc-123',
    *         type: 'custom',
+   *         status: 'RESOLVED',
    *       },
    *     ],
    *   },

--- a/src/resources/profiles/lists.ts
+++ b/src/resources/profiles/lists.ts
@@ -52,7 +52,7 @@ export class Lists extends APIResource {
    * ```ts
    * const response = await client.profiles.lists.subscribe(
    *   'user_id',
-   *   { lists: [{ listId: 'listId' }] },
+   *   { lists: [{ listId: 'example.list.id' }] },
    * );
    * ```
    */

--- a/src/resources/profiles/profiles.ts
+++ b/src/resources/profiles/profiles.ts
@@ -29,7 +29,10 @@ export class Profiles extends APIResource {
    * @example
    * ```ts
    * const profile = await client.profiles.create('user_id', {
-   *   profile: { foo: 'bar' },
+   *   profile: {
+   *     email: 'jdoe@example.com',
+   *     phone_number: '+15558675309',
+   *   },
    * });
    * ```
    */
@@ -80,9 +83,9 @@ export class Profiles extends APIResource {
    * await client.profiles.update('user_id', {
    *   patch: [
    *     {
-   *       op: 'op',
-   *       path: 'path',
-   *       value: 'value',
+   *       op: 'replace',
+   *       path: '/email',
+   *       value: 'jdoe@example.com',
    *     },
    *   ],
    * });
@@ -119,7 +122,11 @@ export class Profiles extends APIResource {
    * @example
    * ```ts
    * const response = await client.profiles.replace('user_id', {
-   *   profile: { foo: 'bar' },
+   *   profile: {
+   *     email: 'jdoe@example.com',
+   *     phone_number: '+15558675309',
+   *     locale: 'en-US',
+   *   },
    * });
    * ```
    */

--- a/src/resources/providers/providers.ts
+++ b/src/resources/providers/providers.ts
@@ -22,7 +22,9 @@ export class Providers extends APIResource {
    * @example
    * ```ts
    * const provider = await client.providers.create({
-   *   provider: 'provider',
+   *   provider: 'sendgrid',
+   *   settings: { api_key: 'SG.xxxxxxxx' },
+   *   title: 'Production SendGrid',
    * });
    * ```
    */
@@ -67,7 +69,9 @@ export class Providers extends APIResource {
    * @example
    * ```ts
    * const provider = await client.providers.update('id', {
-   *   provider: 'provider',
+   *   provider: 'sendgrid',
+   *   settings: { api_key: 'SG.xxxxxxxx' },
+   *   title: 'Production SendGrid',
    * });
    * ```
    */

--- a/src/resources/tenants/templates/templates.ts
+++ b/src/resources/tenants/templates/templates.ts
@@ -84,6 +84,7 @@ export class Templates extends APIResource {
    * const postTenantTemplatePublishResponse =
    *   await client.tenants.templates.publish('template_id', {
    *     tenant_id: 'tenant_id',
+   *     version: 'latest',
    *   });
    * ```
    */
@@ -109,8 +110,13 @@ export class Templates extends APIResource {
    *   await client.tenants.templates.replace('template_id', {
    *     tenant_id: 'tenant_id',
    *     template: {
-   *       content: { elements: [{}], version: 'version' },
+   *       content: {
+   *         version: '2022-01-01',
+   *         elements: [{ type: 'text' }],
+   *       },
+   *       routing: { method: 'single', channels: ['email'] },
    *     },
+   *     published: true,
    *   });
    * ```
    */

--- a/src/resources/tenants/tenants.ts
+++ b/src/resources/tenants/tenants.ts
@@ -47,7 +47,9 @@ export class Tenants extends APIResource {
    * @example
    * ```ts
    * const tenant = await client.tenants.update('tenant_id', {
-   *   name: 'name',
+   *   name: 'Acme Corp',
+   *   brand_id: 'bnd_01kx4mrd0pfzw8wt7pn7p2fzag',
+   *   properties: { plan: 'enterprise' },
    * });
    * ```
    */

--- a/src/resources/translations.ts
+++ b/src/resources/translations.ts
@@ -13,6 +13,14 @@ export class Translations extends APIResource {
   /**
    * Returns the translation strings stored for one domain and locale, for use in
    * localized notification content.
+   *
+   * @example
+   * ```ts
+   * const translation = await client.translations.retrieve(
+   *   'locale',
+   *   { domain: 'domain' },
+   * );
+   * ```
    */
   retrieve(locale: string, params: TranslationRetrieveParams, options?: RequestOptions): APIPromise<string> {
     const { domain } = params;
@@ -22,6 +30,14 @@ export class Translations extends APIResource {
   /**
    * Uploads the translation strings for one domain and locale. Courier uses them to
    * render localized content for recipients in that locale.
+   *
+   * @example
+   * ```ts
+   * await client.translations.update('locale', {
+   *   domain: 'domain',
+   *   body: 'msgid "Hello"\nmsgstr "Hola"',
+   * });
+   * ```
    */
   update(locale: string, params: TranslationUpdateParams, options?: RequestOptions): APIPromise<void> {
     const { domain, body } = params;

--- a/src/resources/users/tenants.ts
+++ b/src/resources/users/tenants.ts
@@ -35,7 +35,10 @@ export class Tenants extends APIResource {
    * @example
    * ```ts
    * await client.users.tenants.addMultiple('user_id', {
-   *   tenants: [{ tenant_id: 'tenant_id' }],
+   *   tenants: [
+   *     { tenant_id: 'tenant_abc' },
+   *     { tenant_id: 'tenant_def' },
+   *   ],
    * });
    * ```
    */
@@ -55,6 +58,7 @@ export class Tenants extends APIResource {
    * ```ts
    * await client.users.tenants.addSingle('tenant_id', {
    *   user_id: 'user_id',
+   *   profile: { role: 'admin' },
    * });
    * ```
    */

--- a/src/resources/users/tokens.ts
+++ b/src/resources/users/tokens.ts
@@ -38,7 +38,13 @@ export class Tokens extends APIResource {
    * ```ts
    * await client.users.tokens.update('token', {
    *   user_id: 'user_id',
-   *   patch: [{ op: 'op', path: 'path' }],
+   *   patch: [
+   *     {
+   *       op: 'replace',
+   *       path: '/expiry_date',
+   *       value: '2024-12-31T00:00:00.000Z',
+   *     },
+   *   ],
    * });
    * ```
    */
@@ -108,6 +114,7 @@ export class Tokens extends APIResource {
    * await client.users.tokens.addSingle('token', {
    *   user_id: 'user_id',
    *   provider_key: 'firebase-fcm',
+   *   device: { app_id: 'com.example.app' },
    * });
    * ```
    */

--- a/src/resources/workspace-preferences/topics.ts
+++ b/src/resources/workspace-preferences/topics.ts
@@ -122,8 +122,11 @@ export class Topics extends APIResource {
    *     'topic_id',
    *     {
    *       section_id: 'section_id',
-   *       default_status: 'OPTED_OUT',
-   *       name: 'name',
+   *       default_status: 'OPTED_IN',
+   *       name: 'Product Updates',
+   *       allowed_preferences: ['channel_preferences'],
+   *       include_unsubscribe_header: true,
+   *       routing_options: ['email', 'inbox'],
    *     },
    *   );
    * ```

--- a/src/resources/workspace-preferences/workspace-preferences.ts
+++ b/src/resources/workspace-preferences/workspace-preferences.ts
@@ -108,7 +108,11 @@ export class WorkspacePreferences extends APIResource {
    * @example
    * ```ts
    * const publishPreferencesResponse =
-   *   await client.workspacePreferences.publish();
+   *   await client.workspacePreferences.publish({
+   *     brand_id: 'bnd_01kx4mrd0pfzw8wt7pn7p2fzag',
+   *     description: 'Choose what you hear from us about.',
+   *     heading: 'Notification Preferences',
+   *   });
    * ```
    */
   publish(
@@ -143,7 +147,9 @@ export class WorkspacePreferences extends APIResource {
    * ```ts
    * const workspacePreferenceGetResponse =
    *   await client.workspacePreferences.replace('section_id', {
-   *     name: 'name',
+   *     name: 'Account Notifications',
+   *     has_custom_routing: true,
+   *     routing_options: ['email', 'push'],
    *   });
    * ```
    */

--- a/tests/api-resources/automations/invoke.test.ts
+++ b/tests/api-resources/automations/invoke.test.ts
@@ -56,7 +56,7 @@ describe('resource invoke', () => {
   // Mock server tests are disabled
   test.skip('invokeByTemplate: only required params', async () => {
     const responsePromise = client.automations.invoke.invokeByTemplate('templateId', {
-      recipient: 'recipient',
+      recipient: 'user_abc',
     });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
@@ -70,10 +70,10 @@ describe('resource invoke', () => {
   // Mock server tests are disabled
   test.skip('invokeByTemplate: required and optional params', async () => {
     const response = await client.automations.invoke.invokeByTemplate('templateId', {
-      recipient: 'recipient',
+      recipient: 'user_abc',
       brand: 'brand',
-      data: { foo: 'bar' },
-      profile: { foo: 'bar' },
+      data: { orderId: 'bar' },
+      profile: { email: 'bar' },
       template: 'template',
       'Idempotency-Key': 'order-ORD-456-user-123',
       'x-idempotency-expiration': '1785312000',

--- a/tests/api-resources/brands.test.ts
+++ b/tests/api-resources/brands.test.ts
@@ -89,7 +89,7 @@ describe('resource brands', () => {
 
   // Mock server tests are disabled
   test.skip('update: only required params', async () => {
-    const responsePromise = client.brands.update('brand_id', { name: 'name' });
+    const responsePromise = client.brands.update('brand_id', { name: 'My Brand' });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -102,9 +102,9 @@ describe('resource brands', () => {
   // Mock server tests are disabled
   test.skip('update: required and optional params', async () => {
     const response = await client.brands.update('brand_id', {
-      name: 'name',
+      name: 'My Brand',
       settings: {
-        colors: { primary: 'primary', secondary: 'secondary' },
+        colors: { primary: '#9D3789', secondary: '#FFFFFF' },
         email: {
           footer: { content: 'content', inheritDefault: true },
           head: { inheritDefault: true, content: 'content' },

--- a/tests/api-resources/bulk.test.ts
+++ b/tests/api-resources/bulk.test.ts
@@ -25,7 +25,7 @@ describe('resource bulk', () => {
     const response = await client.bulk.addUsers('job_id', {
       users: [
         {
-          data: {},
+          data: { name: 'Jane' },
           preferences: {
             categories: {
               foo: {
@@ -42,8 +42,8 @@ describe('resource bulk', () => {
               },
             },
           },
-          profile: { foo: 'bar' },
-          recipient: 'recipient',
+          profile: { email: 'bar' },
+          recipient: 'user_abc',
           to: {
             account_id: 'account_id',
             context: { tenant_id: 'tenant_id' },
@@ -81,7 +81,7 @@ describe('resource bulk', () => {
 
   // Mock server tests are disabled
   test.skip('createJob: only required params', async () => {
-    const responsePromise = client.bulk.createJob({ message: { event: 'event' } });
+    const responsePromise = client.bulk.createJob({ message: { event: 'welcome-series' } });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -95,10 +95,10 @@ describe('resource bulk', () => {
   test.skip('createJob: required and optional params', async () => {
     const response = await client.bulk.createJob({
       message: {
-        event: 'event',
-        brand: 'brand',
+        event: 'welcome-series',
+        brand: 'bnd_01kx4mrd0pfzw8wt7pn7p2fzag',
         content: { body: 'body', title: 'title' },
-        data: { foo: 'bar' },
+        data: { campaign: 'bar' },
         locale: { foo: { foo: 'bar' } },
         override: { foo: 'bar' },
         template: 'template',

--- a/tests/api-resources/lists/lists.test.ts
+++ b/tests/api-resources/lists/lists.test.ts
@@ -22,7 +22,7 @@ describe('resource lists', () => {
 
   // Mock server tests are disabled
   test.skip('update: only required params', async () => {
-    const responsePromise = client.lists.update('list_id', { name: 'name' });
+    const responsePromise = client.lists.update('list_id', { name: 'Product Updates' });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -35,7 +35,7 @@ describe('resource lists', () => {
   // Mock server tests are disabled
   test.skip('update: required and optional params', async () => {
     const response = await client.lists.update('list_id', {
-      name: 'name',
+      name: 'Product Updates',
       preferences: {
         categories: {
           foo: {

--- a/tests/api-resources/lists/subscriptions.test.ts
+++ b/tests/api-resources/lists/subscriptions.test.ts
@@ -31,7 +31,7 @@ describe('resource subscriptions', () => {
   // Mock server tests are disabled
   test.skip('add: only required params', async () => {
     const responsePromise = client.lists.subscriptions.add('list_id', {
-      recipients: [{ recipientId: 'recipientId' }],
+      recipients: [{ recipientId: 'user_abc' }, { recipientId: 'user_def' }],
     });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
@@ -47,7 +47,26 @@ describe('resource subscriptions', () => {
     const response = await client.lists.subscriptions.add('list_id', {
       recipients: [
         {
-          recipientId: 'recipientId',
+          recipientId: 'user_abc',
+          preferences: {
+            categories: {
+              foo: {
+                status: 'OPTED_IN',
+                channel_preferences: [{ channel: 'direct_message' }],
+                rules: [{ until: 'until', start: 'start' }],
+              },
+            },
+            notifications: {
+              foo: {
+                status: 'OPTED_IN',
+                channel_preferences: [{ channel: 'direct_message' }],
+                rules: [{ until: 'until', start: 'start' }],
+              },
+            },
+          },
+        },
+        {
+          recipientId: 'user_def',
           preferences: {
             categories: {
               foo: {
@@ -74,7 +93,7 @@ describe('resource subscriptions', () => {
   // Mock server tests are disabled
   test.skip('subscribe: only required params', async () => {
     const responsePromise = client.lists.subscriptions.subscribe('list_id', {
-      recipients: [{ recipientId: 'recipientId' }],
+      recipients: [{ recipientId: 'user_abc' }, { recipientId: 'user_def' }],
     });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
@@ -90,7 +109,26 @@ describe('resource subscriptions', () => {
     const response = await client.lists.subscriptions.subscribe('list_id', {
       recipients: [
         {
-          recipientId: 'recipientId',
+          recipientId: 'user_abc',
+          preferences: {
+            categories: {
+              foo: {
+                status: 'OPTED_IN',
+                channel_preferences: [{ channel: 'direct_message' }],
+                rules: [{ until: 'until', start: 'start' }],
+              },
+            },
+            notifications: {
+              foo: {
+                status: 'OPTED_IN',
+                channel_preferences: [{ channel: 'direct_message' }],
+                rules: [{ until: 'until', start: 'start' }],
+              },
+            },
+          },
+        },
+        {
+          recipientId: 'user_def',
           preferences: {
             categories: {
               foo: {
@@ -137,7 +175,7 @@ describe('resource subscriptions', () => {
           },
         },
         notifications: {
-          foo: {
+          nt_01kx4h2jdafq8bk9aftxak4b40: {
             status: 'OPTED_IN',
             channel_preferences: [{ channel: 'direct_message' }],
             rules: [{ until: 'until', start: 'start' }],

--- a/tests/api-resources/notifications/checks.test.ts
+++ b/tests/api-resources/notifications/checks.test.ts
@@ -14,7 +14,7 @@ describe('resource checks', () => {
       id: 'id',
       checks: [
         {
-          id: 'id',
+          id: 'abc-123',
           status: 'RESOLVED',
           type: 'custom',
         },
@@ -35,7 +35,7 @@ describe('resource checks', () => {
       id: 'id',
       checks: [
         {
-          id: 'id',
+          id: 'abc-123',
           status: 'RESOLVED',
           type: 'custom',
         },

--- a/tests/api-resources/profiles/lists.test.ts
+++ b/tests/api-resources/profiles/lists.test.ts
@@ -42,7 +42,9 @@ describe('resource lists', () => {
 
   // Mock server tests are disabled
   test.skip('subscribe: only required params', async () => {
-    const responsePromise = client.profiles.lists.subscribe('user_id', { lists: [{ listId: 'listId' }] });
+    const responsePromise = client.profiles.lists.subscribe('user_id', {
+      lists: [{ listId: 'example.list.id' }],
+    });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -57,7 +59,7 @@ describe('resource lists', () => {
     const response = await client.profiles.lists.subscribe('user_id', {
       lists: [
         {
-          listId: 'listId',
+          listId: 'example.list.id',
           preferences: {
             categories: {
               foo: {

--- a/tests/api-resources/profiles/profiles.test.ts
+++ b/tests/api-resources/profiles/profiles.test.ts
@@ -10,7 +10,9 @@ const client = new Courier({
 describe('resource profiles', () => {
   // Mock server tests are disabled
   test.skip('create: only required params', async () => {
-    const responsePromise = client.profiles.create('user_id', { profile: { foo: 'bar' } });
+    const responsePromise = client.profiles.create('user_id', {
+      profile: { email: 'bar', phone_number: 'bar' },
+    });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -23,7 +25,7 @@ describe('resource profiles', () => {
   // Mock server tests are disabled
   test.skip('create: required and optional params', async () => {
     const response = await client.profiles.create('user_id', {
-      profile: { foo: 'bar' },
+      profile: { email: 'bar', phone_number: 'bar' },
       'Idempotency-Key': 'order-ORD-456-user-123',
       'x-idempotency-expiration': '1785312000',
     });
@@ -46,9 +48,9 @@ describe('resource profiles', () => {
     const responsePromise = client.profiles.update('user_id', {
       patch: [
         {
-          op: 'op',
-          path: 'path',
-          value: 'value',
+          op: 'replace',
+          path: '/email',
+          value: 'jdoe@example.com',
         },
       ],
     });
@@ -66,9 +68,9 @@ describe('resource profiles', () => {
     const response = await client.profiles.update('user_id', {
       patch: [
         {
-          op: 'op',
-          path: 'path',
-          value: 'value',
+          op: 'replace',
+          path: '/email',
+          value: 'jdoe@example.com',
         },
       ],
     });
@@ -88,7 +90,13 @@ describe('resource profiles', () => {
 
   // Mock server tests are disabled
   test.skip('replace: only required params', async () => {
-    const responsePromise = client.profiles.replace('user_id', { profile: { foo: 'bar' } });
+    const responsePromise = client.profiles.replace('user_id', {
+      profile: {
+        email: 'bar',
+        phone_number: 'bar',
+        locale: 'bar',
+      },
+    });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -100,6 +108,12 @@ describe('resource profiles', () => {
 
   // Mock server tests are disabled
   test.skip('replace: required and optional params', async () => {
-    const response = await client.profiles.replace('user_id', { profile: { foo: 'bar' } });
+    const response = await client.profiles.replace('user_id', {
+      profile: {
+        email: 'bar',
+        phone_number: 'bar',
+        locale: 'bar',
+      },
+    });
   });
 });

--- a/tests/api-resources/providers/providers.test.ts
+++ b/tests/api-resources/providers/providers.test.ts
@@ -10,7 +10,7 @@ const client = new Courier({
 describe('resource providers', () => {
   // Mock server tests are disabled
   test.skip('create: only required params', async () => {
-    const responsePromise = client.providers.create({ provider: 'provider' });
+    const responsePromise = client.providers.create({ provider: 'sendgrid' });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -23,10 +23,10 @@ describe('resource providers', () => {
   // Mock server tests are disabled
   test.skip('create: required and optional params', async () => {
     const response = await client.providers.create({
-      provider: 'provider',
+      provider: 'sendgrid',
       alias: 'alias',
-      settings: { foo: 'bar' },
-      title: 'title',
+      settings: { api_key: 'bar' },
+      title: 'Production SendGrid',
       'Idempotency-Key': 'order-ORD-456-user-123',
       'x-idempotency-expiration': '1785312000',
     });
@@ -46,7 +46,7 @@ describe('resource providers', () => {
 
   // Mock server tests are disabled
   test.skip('update: only required params', async () => {
-    const responsePromise = client.providers.update('id', { provider: 'provider' });
+    const responsePromise = client.providers.update('id', { provider: 'sendgrid' });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -59,10 +59,10 @@ describe('resource providers', () => {
   // Mock server tests are disabled
   test.skip('update: required and optional params', async () => {
     const response = await client.providers.update('id', {
-      provider: 'provider',
+      provider: 'sendgrid',
       alias: 'alias',
-      settings: { foo: 'bar' },
-      title: 'title',
+      settings: { api_key: 'bar' },
+      title: 'Production SendGrid',
     });
   });
 

--- a/tests/api-resources/tenants/templates/templates.test.ts
+++ b/tests/api-resources/tenants/templates/templates.test.ts
@@ -82,7 +82,7 @@ describe('resource templates', () => {
   test.skip('publish: required and optional params', async () => {
     const response = await client.tenants.templates.publish('template_id', {
       tenant_id: 'tenant_id',
-      version: 'version',
+      version: 'latest',
     });
   });
 
@@ -90,7 +90,7 @@ describe('resource templates', () => {
   test.skip('replace: only required params', async () => {
     const responsePromise = client.tenants.templates.replace('template_id', {
       tenant_id: 'tenant_id',
-      template: { content: { elements: [{}], version: 'version' } },
+      template: { content: { elements: [{}], version: '2022-01-01' } },
     });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
@@ -116,7 +116,7 @@ describe('resource templates', () => {
               type: 'text',
             },
           ],
-          version: 'version',
+          version: '2022-01-01',
         },
         channels: {
           foo: {
@@ -153,7 +153,7 @@ describe('resource templates', () => {
             timeouts: 0,
           },
         },
-        routing: { channels: ['string'], method: 'all' },
+        routing: { channels: ['email'], method: 'single' },
       },
       published: true,
     });

--- a/tests/api-resources/tenants/tenants.test.ts
+++ b/tests/api-resources/tenants/tenants.test.ts
@@ -22,7 +22,7 @@ describe('resource tenants', () => {
 
   // Mock server tests are disabled
   test.skip('update: only required params', async () => {
-    const responsePromise = client.tenants.update('tenant_id', { name: 'name' });
+    const responsePromise = client.tenants.update('tenant_id', { name: 'Acme Corp' });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -35,8 +35,8 @@ describe('resource tenants', () => {
   // Mock server tests are disabled
   test.skip('update: required and optional params', async () => {
     const response = await client.tenants.update('tenant_id', {
-      name: 'name',
-      brand_id: 'brand_id',
+      name: 'Acme Corp',
+      brand_id: 'bnd_01kx4mrd0pfzw8wt7pn7p2fzag',
       default_preferences: {
         items: [
           {
@@ -48,7 +48,7 @@ describe('resource tenants', () => {
         ],
       },
       parent_tenant_id: 'parent_tenant_id',
-      properties: { foo: 'bar' },
+      properties: { plan: 'bar' },
       user_profile: { foo: 'bar' },
     });
   });

--- a/tests/api-resources/translations.test.ts
+++ b/tests/api-resources/translations.test.ts
@@ -27,7 +27,10 @@ describe('resource translations', () => {
 
   // Mock server tests are disabled
   test.skip('update: only required params', async () => {
-    const responsePromise = client.translations.update('locale', { domain: 'domain', body: 'body' });
+    const responsePromise = client.translations.update('locale', {
+      domain: 'domain',
+      body: 'msgid "Hello"\nmsgstr "Hola"',
+    });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -39,6 +42,9 @@ describe('resource translations', () => {
 
   // Mock server tests are disabled
   test.skip('update: required and optional params', async () => {
-    const response = await client.translations.update('locale', { domain: 'domain', body: 'body' });
+    const response = await client.translations.update('locale', {
+      domain: 'domain',
+      body: 'msgid "Hello"\nmsgstr "Hola"',
+    });
   });
 });

--- a/tests/api-resources/users/tenants.test.ts
+++ b/tests/api-resources/users/tenants.test.ts
@@ -35,7 +35,7 @@ describe('resource tenants', () => {
   // Mock server tests are disabled
   test.skip('addMultiple: only required params', async () => {
     const responsePromise = client.users.tenants.addMultiple('user_id', {
-      tenants: [{ tenant_id: 'tenant_id' }],
+      tenants: [{ tenant_id: 'tenant_abc' }, { tenant_id: 'tenant_def' }],
     });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
@@ -51,7 +51,13 @@ describe('resource tenants', () => {
     const response = await client.users.tenants.addMultiple('user_id', {
       tenants: [
         {
-          tenant_id: 'tenant_id',
+          tenant_id: 'tenant_abc',
+          profile: { foo: 'bar' },
+          type: 'user',
+          user_id: 'user_id',
+        },
+        {
+          tenant_id: 'tenant_def',
           profile: { foo: 'bar' },
           type: 'user',
           user_id: 'user_id',
@@ -76,7 +82,7 @@ describe('resource tenants', () => {
   test.skip('addSingle: required and optional params', async () => {
     const response = await client.users.tenants.addSingle('tenant_id', {
       user_id: 'user_id',
-      profile: { foo: 'bar' },
+      profile: { role: 'bar' },
     });
   });
 

--- a/tests/api-resources/users/tokens.test.ts
+++ b/tests/api-resources/users/tokens.test.ts
@@ -29,7 +29,7 @@ describe('resource tokens', () => {
   test.skip('update: only required params', async () => {
     const responsePromise = client.users.tokens.update('token', {
       user_id: 'user_id',
-      patch: [{ op: 'op', path: 'path' }],
+      patch: [{ op: 'replace', path: '/expiry_date' }],
     });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
@@ -46,9 +46,9 @@ describe('resource tokens', () => {
       user_id: 'user_id',
       patch: [
         {
-          op: 'op',
-          path: 'path',
-          value: 'value',
+          op: 'replace',
+          path: '/expiry_date',
+          value: '2024-12-31T00:00:00.000Z',
         },
       ],
     });
@@ -117,7 +117,7 @@ describe('resource tokens', () => {
       provider_key: 'firebase-fcm',
       device: {
         ad_id: 'ad_id',
-        app_id: 'app_id',
+        app_id: 'com.example.app',
         device_id: 'device_id',
         manufacturer: 'manufacturer',
         model: 'model',

--- a/tests/api-resources/workspace-preferences/topics.test.ts
+++ b/tests/api-resources/workspace-preferences/topics.test.ts
@@ -96,8 +96,8 @@ describe('resource topics', () => {
   test.skip('replace: only required params', async () => {
     const responsePromise = client.workspacePreferences.topics.replace('topic_id', {
       section_id: 'section_id',
-      default_status: 'OPTED_OUT',
-      name: 'name',
+      default_status: 'OPTED_IN',
+      name: 'Product Updates',
     });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
@@ -112,12 +112,12 @@ describe('resource topics', () => {
   test.skip('replace: required and optional params', async () => {
     const response = await client.workspacePreferences.topics.replace('topic_id', {
       section_id: 'section_id',
-      default_status: 'OPTED_OUT',
-      name: 'name',
-      allowed_preferences: ['snooze'],
+      default_status: 'OPTED_IN',
+      name: 'Product Updates',
+      allowed_preferences: ['channel_preferences'],
       description: 'description',
       include_unsubscribe_header: true,
-      routing_options: ['direct_message'],
+      routing_options: ['email', 'inbox'],
       topic_data: { foo: 'bar' },
     });
   });

--- a/tests/api-resources/workspace-preferences/workspace-preferences.test.ts
+++ b/tests/api-resources/workspace-preferences/workspace-preferences.test.ts
@@ -86,9 +86,9 @@ describe('resource workspacePreferences', () => {
     await expect(
       client.workspacePreferences.publish(
         {
-          brand_id: 'brand_id',
-          description: 'description',
-          heading: 'heading',
+          brand_id: 'bnd_01kx4mrd0pfzw8wt7pn7p2fzag',
+          description: 'Choose what you hear from us about.',
+          heading: 'Notification Preferences',
           'Idempotency-Key': 'order-ORD-456-user-123',
           'x-idempotency-expiration': '1785312000',
         },
@@ -99,7 +99,9 @@ describe('resource workspacePreferences', () => {
 
   // Mock server tests are disabled
   test.skip('replace: only required params', async () => {
-    const responsePromise = client.workspacePreferences.replace('section_id', { name: 'name' });
+    const responsePromise = client.workspacePreferences.replace('section_id', {
+      name: 'Account Notifications',
+    });
     const rawResponse = await responsePromise.asResponse();
     expect(rawResponse).toBeInstanceOf(Response);
     const response = await responsePromise;
@@ -112,10 +114,10 @@ describe('resource workspacePreferences', () => {
   // Mock server tests are disabled
   test.skip('replace: required and optional params', async () => {
     const response = await client.workspacePreferences.replace('section_id', {
-      name: 'name',
+      name: 'Account Notifications',
       description: 'description',
       has_custom_routing: true,
-      routing_options: ['direct_message'],
+      routing_options: ['email', 'push'],
     });
   });
 });


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

33 files changed, 324 insertions(+), 96 deletions(-)

<details><summary>Files</summary>

```
 src/resources/audiences.ts                                      | 46 +++++++++++++++++++++++++++
 src/resources/automations/invoke.ts                             |  6 +++-
 src/resources/brands.ts                                         |  5 ++-
 src/resources/bulk.ts                                           | 39 +++++++++++++++++++++++
 src/resources/lists/lists.ts                                    |  4 ++-
 src/resources/lists/subscriptions.ts                            | 15 +++++++--
 src/resources/notifications/checks.ts                           |  4 +--
 src/resources/profiles/lists.ts                                 |  2 +-
 src/resources/profiles/profiles.ts                              | 17 +++++++---
 src/resources/providers/providers.ts                            |  8 +++--
 src/resources/tenants/templates/templates.ts                    |  8 ++++-
 src/resources/tenants/tenants.ts                                |  4 ++-
 src/resources/translations.ts                                   | 16 ++++++++++
 src/resources/users/tenants.ts                                  |  6 +++-
 src/resources/users/tokens.ts                                   |  9 +++++-
 src/resources/workspace-preferences/topics.ts                   |  7 +++--
 src/resources/workspace-preferences/workspace-preferences.ts    | 10 ++++--
 tests/api-resources/automations/invoke.test.ts                  |  8 ++---
 tests/api-resources/brands.test.ts                              |  6 ++--
 tests/api-resources/bulk.test.ts                                | 14 ++++-----
 tests/api-resources/lists/lists.test.ts                         |  4 +--
 tests/api-resources/lists/subscriptions.test.ts                 | 48 ++++++++++++++++++++++++++---
 tests/api-resources/notifications/checks.test.ts                |  4 +--
 tests/api-resources/profiles/lists.test.ts                      |  6 ++--
 tests/api-resources/profiles/profiles.test.ts                   | 34 ++++++++++++++------
 tests/api-resources/providers/providers.test.ts                 | 16 +++++-----
 tests/api-resources/tenants/templates/templates.test.ts         |  8 ++---
 tests/api-resources/tenants/tenants.test.ts                     |  8 ++---
 tests/api-resources/translations.test.ts                        | 10 ++++--
 tests/api-resources/users/tenants.test.ts                       | 12 ++++++--
 tests/api-resources/users/tokens.test.ts                        | 10 +++---
 tests/api-resources/workspace-preferences/topics.test.ts        | 12 ++++----
 .../workspace-preferences/workspace-preferences.test.ts         | 14 +++++----
 33 files changed, 324 insertions(+), 96 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

Merging with a releasable Conventional Commit title (`feat`/`fix`/`perf`) lets release-please open a release PR; `chore`/`docs` land in the changelog without cutting a release.
