### PR TITLE
docs(api): say what the bulk job endpoints return

### DIFF
--- a/src/resources/bulk.ts
+++ b/src/resources/bulk.ts
@@ -62,7 +62,8 @@ export class Bulk extends APIResource {
   }
 
   /**
-   * Get Bulk Job Users
+   * Returns the users ingested into a bulk job with paging, each carrying the status
+   * Courier recorded for it and the id of the message it produced.
    *
    * @example
    * ```ts
@@ -78,7 +79,9 @@ export class Bulk extends APIResource {
   }
 
   /**
-   * Get a bulk job
+   * Returns a bulk job's message definition, its status — CREATED, PROCESSING,
+   * COMPLETED, or ERROR — and running counts of users received, messages enqueued,
+   * and failures. Poll it to follow a job through to completion.
    *
    * @example
    * ```ts
@@ -90,7 +93,9 @@ export class Bulk extends APIResource {
   }
 
   /**
-   * Run a bulk job
+   * Starts processing a bulk job, sending to every user ingested into it. Returns
+   * 204 immediately; the job runs asynchronously, so poll the job to watch its
+   * status and counts.
    *
    * @example
    * ```ts


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

1 file changed, 8 insertions(+), 3 deletions(-)

<details><summary>Files</summary>

```
 src/resources/bulk.ts | 11 ++++++++---
 1 file changed, 8 insertions(+), 3 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
