### PR TITLE
feat(api)!: nest the AWS SNS target_arn under aws_sns on the user profile

### DIFF
--- a/api.md
+++ b/api.md
@@ -8,6 +8,7 @@ Types:
 - <code><a href="./src/resources/shared.ts">AudienceFilter</a></code>
 - <code><a href="./src/resources/shared.ts">AudienceFilterConfig</a></code>
 - <code><a href="./src/resources/shared.ts">AudienceRecipient</a></code>
+- <code><a href="./src/resources/shared.ts">AwsSns</a></code>
 - <code><a href="./src/resources/shared.ts">Channel</a></code>
 - <code><a href="./src/resources/shared.ts">ChannelClassification</a></code>
 - <code><a href="./src/resources/shared.ts">ChannelMetadata</a></code>

--- a/src/client.ts
+++ b/src/client.ts
@@ -1395,6 +1395,7 @@ export declare namespace Courier {
   export type AudienceFilter = API.AudienceFilter;
   export type AudienceFilterConfig = API.AudienceFilterConfig;
   export type AudienceRecipient = API.AudienceRecipient;
+  export type AwsSns = API.AwsSns;
   export type Channel = API.Channel;
   export type ChannelClassification = API.ChannelClassification;
   export type ChannelMetadata = API.ChannelMetadata;

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -57,6 +57,18 @@ export interface AudienceRecipient {
   filters?: Array<AudienceFilter> | null;
 }
 
+/**
+ * Routes a push notification through the AWS SNS provider. The target ARN must be
+ * nested under `aws_sns` — a top-level `target_arn` on the profile is ignored by
+ * the provider.
+ */
+export interface AwsSns {
+  /**
+   * The ARN of the SNS platform endpoint, topic, or application to publish to.
+   */
+  target_arn: string;
+}
+
 export interface Channel {
   /**
    * Brand id used for rendering.
@@ -540,6 +552,13 @@ export interface UserProfile {
 
   apn?: string | null;
 
+  /**
+   * Routes a push notification through the AWS SNS provider. The target ARN must be
+   * nested under `aws_sns` — a top-level `target_arn` on the profile is ignored by
+   * the provider.
+   */
+  aws_sns?: AwsSns | null;
+
   birthdate?: string | null;
 
   /**
@@ -591,8 +610,6 @@ export interface UserProfile {
   slack?: Slack | null;
 
   sub?: string | null;
-
-  target_arn?: string | null;
 
   updated_at?: string | null;
 


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

3 files changed, 21 insertions(+), 2 deletions(-)

<details><summary>Files</summary>

```
 api.md                  |  1 +
 src/client.ts           |  1 +
 src/resources/shared.ts | 21 +++++++++++++++++++--
 3 files changed, 21 insertions(+), 2 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
