### PR TITLE
feat(api)!: match the spec to the backend — apn/expo token types and the phantom notifications.duplicate

### DIFF
--- a/.stats.yml
+++ b/.stats.yml
@@ -1,1 +1,1 @@
-configured_endpoints: 150
+configured_endpoints: 149

--- a/api.md
+++ b/api.md
@@ -5,6 +5,7 @@ Types:
 - <code><a href="./src/resources/shared.ts">AirshipProfile</a></code>
 - <code><a href="./src/resources/shared.ts">AirshipProfileAudience</a></code>
 - <code><a href="./src/resources/shared.ts">Alignment</a></code>
+- <code><a href="./src/resources/shared.ts">Apn</a></code>
 - <code><a href="./src/resources/shared.ts">AudienceFilter</a></code>
 - <code><a href="./src/resources/shared.ts">AudienceFilterConfig</a></code>
 - <code><a href="./src/resources/shared.ts">AudienceRecipient</a></code>
@@ -430,7 +431,6 @@ Methods:
 - <code title="get /notifications/{id}">client.notifications.<a href="./src/resources/notifications/notifications.ts">retrieve</a>(id, { ...params }) -> NotificationTemplateResponse</code>
 - <code title="get /notifications">client.notifications.<a href="./src/resources/notifications/notifications.ts">list</a>({ ...params }) -> NotificationListResponse</code>
 - <code title="delete /notifications/{id}">client.notifications.<a href="./src/resources/notifications/notifications.ts">archive</a>(id) -> void</code>
-- <code title="post /notifications/{id}/duplicate">client.notifications.<a href="./src/resources/notifications/notifications.ts">duplicate</a>(id) -> NotificationTemplateResponse</code>
 - <code title="get /notifications/{id}/versions">client.notifications.<a href="./src/resources/notifications/notifications.ts">listVersions</a>(id, { ...params }) -> NotificationTemplateVersionListResponse</code>
 - <code title="post /notifications/{id}/publish">client.notifications.<a href="./src/resources/notifications/notifications.ts">publish</a>(id, { ...params }) -> void</code>
 - <code title="put /notifications/{id}/content">client.notifications.<a href="./src/resources/notifications/notifications.ts">putContent</a>(id, { ...params }) -> NotificationContentMutationResponse</code>

--- a/src/client.ts
+++ b/src/client.ts
@@ -1392,6 +1392,7 @@ export declare namespace Courier {
   export type AirshipProfile = API.AirshipProfile;
   export type AirshipProfileAudience = API.AirshipProfileAudience;
   export type Alignment = API.Alignment;
+  export type Apn = API.Apn;
   export type AudienceFilter = API.AudienceFilter;
   export type AudienceFilterConfig = API.AudienceFilterConfig;
   export type AudienceRecipient = API.AudienceRecipient;

--- a/src/resources/notifications/notifications.ts
+++ b/src/resources/notifications/notifications.ts
@@ -125,21 +125,6 @@ export class Notifications extends APIResource {
   }
 
   /**
-   * Copies a notification template within the same workspace and environment,
-   * appending " COPY" to the title. The copy is standalone and independently
-   * editable.
-   *
-   * @example
-   * ```ts
-   * const notificationTemplateResponse =
-   *   await client.notifications.duplicate('id');
-   * ```
-   */
-  duplicate(id: string, options?: RequestOptions): APIPromise<NotificationTemplateResponse> {
-    return this._client.post(path`/notifications/${id}/duplicate`, options);
-  }
-
-  /**
    * Returns a notification template's published versions, most recent first, for
    * comparison or rollback. Paged.
    *

--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -14,6 +14,13 @@ export interface AirshipProfileAudience {
 
 export type Alignment = 'center' | 'left' | 'right' | 'full';
 
+/**
+ * Apple Push Notification device tokens. Supply either a single `token` or a
+ * `tokens` value. A bare string is rejected by the provider — the token must be
+ * wrapped in this object.
+ */
+export type Apn = Token | MultipleTokens;
+
 export interface AudienceFilter {
   /**
    * Send to users only if they are member of the account
@@ -259,6 +266,9 @@ export interface ElementalTextNodeWithType extends ElementalBaseNode {
   type?: 'text';
 }
 
+/**
+ * Expo push tokens. Supply either a single `token` or a `tokens` value.
+ */
 export type Expo = Token | MultipleTokens;
 
 /**
@@ -394,7 +404,11 @@ export interface MsTeamsRecipient {
 }
 
 export interface MultipleTokens {
-  tokens: Array<Token>;
+  /**
+   * One device token, or an array of them. The values are the token strings
+   * themselves — not objects.
+   */
+  tokens: string | Array<string>;
 }
 
 export interface NotificationPreferenceDetails {
@@ -550,7 +564,12 @@ export interface UserProfile {
 
   airship?: AirshipProfile | null;
 
-  apn?: string | null;
+  /**
+   * Apple Push Notification device tokens. Supply either a single `token` or a
+   * `tokens` value. A bare string is rejected by the provider — the token must be
+   * wrapped in this object.
+   */
+  apn?: Apn | null;
 
   /**
    * Routes a push notification through the AWS SNS provider. The target ARN must be
@@ -573,6 +592,9 @@ export interface UserProfile {
 
   email_verified?: boolean | null;
 
+  /**
+   * Expo push tokens. Supply either a single `token` or a `tokens` value.
+   */
   expo?: Expo | null;
 
   facebookPSID?: string | null;

--- a/tests/api-resources/notifications/notifications.test.ts
+++ b/tests/api-resources/notifications/notifications.test.ts
@@ -107,18 +107,6 @@ describe('resource notifications', () => {
   });
 
   // Mock server tests are disabled
-  test.skip('duplicate', async () => {
-    const responsePromise = client.notifications.duplicate('id');
-    const rawResponse = await responsePromise.asResponse();
-    expect(rawResponse).toBeInstanceOf(Response);
-    const response = await responsePromise;
-    expect(response).not.toBeInstanceOf(Response);
-    const dataAndResponse = await responsePromise.withResponse();
-    expect(dataAndResponse.data).toBe(response);
-    expect(dataAndResponse.response).toBe(rawResponse);
-  });
-
-  // Mock server tests are disabled
   test.skip('listVersions', async () => {
     const responsePromise = client.notifications.listVersions('id');
     const rawResponse = await responsePromise.asResponse();


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

**1 endpoint(s) removed**

- `POST /notifications/{id}/duplicate` — Duplicate Notification Template


## What changed in this SDK

6 files changed, 27 insertions(+), 31 deletions(-)

<details><summary>Files</summary>

```
 .stats.yml                                              |  2 +-
 api.md                                                  |  2 +-
 src/client.ts                                           |  1 +
 src/resources/notifications/notifications.ts            | 15 ---------------
 src/resources/shared.ts                                 | 26 ++++++++++++++++++++++++--
 tests/api-resources/notifications/notifications.test.ts | 12 ------------
 6 files changed, 27 insertions(+), 31 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
