### PR TITLE
feat(api): document section_id and section_name on a user's topic preference

### DIFF
--- a/src/resources/users/preferences.ts
+++ b/src/resources/users/preferences.ts
@@ -244,6 +244,20 @@ export interface TopicPreference {
    * custom_routing) rather than the topic's default routing.
    */
   has_custom_routing?: boolean | null;
+
+  /**
+   * The unique identifier of the section this topic belongs to. Always present when
+   * listing a user's preferences; omitted by the single-topic read when the topic
+   * has no resolvable section.
+   */
+  section_id?: string;
+
+  /**
+   * The display name of the section this topic belongs to. Always present when
+   * listing a user's preferences; omitted by the single-topic read when the topic
+   * has no resolvable section.
+   */
+  section_name?: string;
 }
 
 export interface PreferenceRetrieveResponse {


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

1 file changed, 14 insertions(+)

<details><summary>Files</summary>

```
 src/resources/users/preferences.ts | 14 ++++++++++++++
 1 file changed, 14 insertions(+)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
