### PR TITLE
feat(api): document channel on journey send nodes [C-20309]

### DIFF
--- a/src/resources/journeys/journeys.ts
+++ b/src/resources/journeys/journeys.ts
@@ -1045,6 +1045,14 @@ export interface JourneySendNode {
   id?: string;
 
   /**
+   * The channel this node sends through. Optional — when omitted, the field is
+   * absent from the node, including on `GET`; nodes created before this field
+   * existed have it unset. Setting it makes the node's channel explicit to any
+   * client reading the journey.
+   */
+  channel?: 'email' | 'sms' | 'push' | 'inbox' | 'slack' | 'msteams';
+
+  /**
    * Condition spec for a journey node. Accepts a single condition atom, an AND/OR
    * group, or an AND/OR nested group. Omit the `conditions` property entirely to
    * express "no conditions".

--- a/tests/api-resources/journeys/journeys.test.ts
+++ b/tests/api-resources/journeys/journeys.test.ts
@@ -66,6 +66,7 @@ describe('resource journeys', () => {
           },
           type: 'send',
           id: 'send-1',
+          channel: 'email',
           conditions: ['string', 'string'],
           experiment: {
             bucketingKey: 'x',


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

2 files changed, 9 insertions(+)

<details><summary>Files</summary>

```
 src/resources/journeys/journeys.ts            | 8 ++++++++
 tests/api-resources/journeys/journeys.test.ts | 1 +
 2 files changed, 9 insertions(+)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
