### PR TITLE
fix(api): correct two Elemental field names the REST API rejects

### DIFF
--- a/src/resources/shared.ts
+++ b/src/resources/shared.ts
@@ -353,7 +353,7 @@ export interface ElementalImageNode extends ElementalBaseNode {
   /**
    * Alternate text for the image.
    */
-  altText?: string | null;
+  alt_text?: string | null;
 
   /**
    * CSS border color applied to the image. For example, `#ccc`
@@ -439,7 +439,7 @@ export interface ElementalQuoteNode extends ElementalBaseNode {
   /**
    * CSS border color property. For example, `#fff`
    */
-  borderColor?: string | null;
+  border_color?: string | null;
 
   /**
    * CSS px font size for this quote block, e.g. `16px`. Overrides the size of the


### PR DESCRIPTION
Regenerated SDK.

## What changed in the API

No endpoints added or removed — this updates generated code only.

## What changed in this SDK

1 file changed, 2 insertions(+), 2 deletions(-)

<details><summary>Files</summary>

```
 src/resources/shared.ts | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

</details>

This branch is rebuilt from `main` on every spec change and force-pushed, so it always reflects the latest generated output. Hand-written files in this repository are left untouched; anything under the generated surface is replaced on the next update, so fix the specification rather than editing here.

This PR is squash-merged automatically by the api-spec merge job, which then lets release-please open this SDK's release PR. Every type in `release-please-config.json` except `test` and `ci` is a non-hidden changelog section, so `docs` and `chore` cut a patch just as `feat`/`fix` do.
